### PR TITLE
Fix failing imagerotate with 180° rotation (rare corner case)

### DIFF
--- a/modules/captcha/captcha.php
+++ b/modules/captcha/captcha.php
@@ -19,130 +19,110 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.        *
 *******************************************************************************/
 
-class Captcha
- {
-  function check_captcha($code,$entered_code)
-   {
-    if(strtolower($entered_code) == strtolower($code)) return true;
-    else return false;
-   }
+class Captcha {
+	function check_captcha($code, $entered_code) {
+		if (strtolower($entered_code) == strtolower($code)) return true;
+		else return false;
+	}
 
-  function generate_code($letters='abcdefhjkmnpqrstuvwxyz234568')
-   {
-    mt_srand((double)microtime()*1000000);
-    $code='';
-    for($i=0;$i<5;$i++)
-     {
-      $code.=substr($letters,mt_rand(0,strlen($letters)-1),1);
-     }
-    return $code;
-   }
+	function generate_code($letters = 'abcdefhjkmnpqrstuvwxyz234568') {
+		mt_srand((double)microtime()*1000000);
+		$code = '';
+		for ($i = 0; $i < 5; $i++) {
+			$code .= substr($letters, mt_rand(0, strlen($letters) -1), 1);
+		}
+		return $code;
+	}
 
-  function generate_image($code,$backgrounds_folder='',$fonts_folder='')
-   {
-    $font_size = 23;
-    $font_pos_x = 10;
-    $font_pos_y = 30;
+	function generate_image($code, $backgrounds_folder = '', $fonts_folder = '') {
+		$font_size = 23;
+		$font_pos_x = 10;
+		$font_pos_y = 30;
 
-    // get background images:
-    if($backgrounds_folder!='')
-     {
-      $handle=opendir($backgrounds_folder);
-      while ($file = readdir($handle))
-       {
-        if(preg_match('/\.png$/i', $file) || preg_match('/\.gif$/i', $file) || preg_match('/\.jpg$/i', $file)) $backgrounds[] = $file;
-       }
-      closedir($handle);
-     }
+		// get background images:
+		if ($backgrounds_folder != '') {
+			$handle = opendir($backgrounds_folder);
+			while ($file = readdir($handle)) {
+				if (preg_match('/\.png$/i', $file) || preg_match('/\.gif$/i', $file) || preg_match('/\.jpg$/i', $file)) $backgrounds[] = $file;
+			}
+			closedir($handle);
+		}
 
-    // get fonts:
-    if($fonts_folder!='')
-     {
-      $handle=opendir($fonts_folder);
-      while($file = readdir($handle))
-       {
-        if(preg_match('/\.ttf$/i', $file)) $fonts[] = $file;
-       }
-      closedir($handle);
-     }
+		// get fonts:
+		if ($fonts_folder != '') {
+			$handle = opendir($fonts_folder);
+			while ($file = readdir($handle)) {
+				if (preg_match('/\.ttf$/i', $file)) $fonts[] = $file;
+			}
+			closedir($handle);
+		}
 
-    // split code into chars:
-    $code_length = strlen($code);
-      for($i=0;$i<$code_length;$i++)
-       {
-        $code_chars_array[] = substr($code,$i,1);
-       }
+		// split code into chars:
+		$code_length = strlen($code);
+		for ($i = 0; $i < $code_length; $i++) {
+			$code_chars_array[] = substr($code, $i, 1);
+		}
 
-    // if background images are available, craete image from one of them:
-    if(isset($backgrounds))
-     {
-      $bg = $backgrounds[mt_rand(0,count($backgrounds)-1)];
-      if(preg_match('/\.png$/i', $bg)) $im = ImageCreateFromPNG($backgrounds_folder.$bg);
-      elseif(preg_match('/\.gif$/i', $bg)) $im = ImageCreateFromGIF($backgrounds_folder.$bg);
-      else $im = ImageCreateFromJPEG($backgrounds_folder.$bg);
-      if (function_exists('imageflip') && mt_rand(0, 5) % 2 == 0) {
-       $flipConsts = [IMG_FLIP_HORIZONTAL, IMG_FLIP_VERTICAL, IMG_FLIP_BOTH];
-       $flipper = mt_rand(0, 2);
-       imageflip($im, $flipConsts[$flipper]);
-      }
-     }
-    // if not, create an empty image:
-    else
-     {
-      $im = ImageCreate(180, 40);
-      $background_color = ImageColorAllocate ($im, 234, 234, 234);
-     }
+		// if background images are available, craete image from one of them:
+		if (isset($backgrounds)) {
+			$bg = $backgrounds[mt_rand(0,count($backgrounds)-1)];
+			if (preg_match('/\.png$/i', $bg)) $im = ImageCreateFromPNG($backgrounds_folder.$bg);
+			else if (preg_match('/\.gif$/i', $bg)) $im = ImageCreateFromGIF($backgrounds_folder.$bg);
+			else $im = ImageCreateFromJPEG($backgrounds_folder.$bg);
+			if (function_exists('imageflip') && mt_rand(0, 5) % 2 == 0) {
+				$flipConsts = [IMG_FLIP_HORIZONTAL, IMG_FLIP_VERTICAL, IMG_FLIP_BOTH];
+				$flipper = mt_rand(0, 2);
+				imageflip($im, $flipConsts[$flipper]);
+			}
+		} else {
+			// if not, create an empty image:
+ 			$im = ImageCreate(180, 40);
+			$background_color = ImageColorAllocate ($im, 234, 234, 234);
+		}
 
-    // set text color:
-    $text_color = ImageColorAllocate ($im, 0, 0, 0);
+		// set text color:
+		$text_color = ImageColorAllocate ($im, 0, 0, 0);
 
-    // use fonts, if available:
-    if(isset($fonts))
-     {
-      foreach($code_chars_array as $char)
-       {
-        $angle = intval(rand((30 * -1), 30));
-        ImageTTFText($im, $font_size, $angle, $font_pos_x, $font_pos_y, $text_color, $fonts_folder.$fonts[mt_rand(0,count($fonts)-1)],$char);
-        $font_pos_x=$font_pos_x+($font_size+13);
-       }
-     }
-    // if not, use internal font:
-    else
-     {
-      ImageString($im, 5, 30, 10, $code, $text_color);
-     }
-    header("Expires: Expires: Sat, 20 Oct 2007 00:00:00 GMT");
-    header("Cache-Control: max-age=0");
-    header("Content-type: image/png");
-    ImagePNG($im);
-    exit();
-   }
+		// use fonts, if available:
+		if (isset($fonts)) {
+			foreach ($code_chars_array as $char) {
+				$angle = intval(rand((30 * -1), 30));
+				ImageTTFText($im, $font_size, $angle, $font_pos_x, $font_pos_y, $text_color, $fonts_folder.$fonts[mt_rand(0, count($fonts) -1)], $char);
+				$font_pos_x = $font_pos_x + ($font_size + 13);
+			}
+		} else {
+			// if not, use internal font:
+			ImageString($im, 5, 30, 10, $code, $text_color);
+		}
+		header("Expires: Expires: Sat, 20 Oct 2007 00:00:00 GMT");
+		header("Cache-Control: max-age=0");
+		header("Content-type: image/png");
+		ImagePNG($im);
+		exit();
+	}
 
-  function generate_dummy_image()
-   {
-    $im = @ImageCreate(180, 40);
-    $background_color = ImageColorAllocate ($im, 234, 234, 234);
-    $text_color = ImageColorAllocate ($im, 0, 0, 0);
-    #ImageString($im, 3, 7, 4, 'CAPTCHA not available', $text_color);
-    header("Expires: Expires: Sat, 20 Oct 2007 00:00:00 GMT");
-    header("Cache-Control: max-age=0");
-    header("Content-type: image/png");
-    ImagePNG($im);
-   }
+	function generate_dummy_image() {
+		$im = @ImageCreate(180, 40);
+		$background_color = ImageColorAllocate ($im, 234, 234, 234);
+		$text_color = ImageColorAllocate ($im, 0, 0, 0);
+		//ImageString($im, 3, 7, 4, 'CAPTCHA not available', $text_color);
+		header("Expires: Expires: Sat, 20 Oct 2007 00:00:00 GMT");
+		header("Cache-Control: max-age=0");
+		header("Content-type: image/png");
+		ImagePNG($im);
+	}
 
-  // for math CAPTCHA:
-  function generate_math_captcha($number1from=1,$number1to=10,$number2from=0,$number2to=10)
-   {
-    $number[0] = rand($number1from,$number1to);
-    $number[1] = rand($number2from,$number2to);
-    $number[2] = $number[0] + $number[1];
-    return $number;
-   }
+	// for math CAPTCHA:
+	function generate_math_captcha($number1from = 1, $number1to = 10, $number2from = 0, $number2to = 10) {
+		$number[0] = rand($number1from, $number1to);
+		$number[1] = rand($number2from, $number2to);
+		$number[2] = $number[0] + $number[1];
+		return $number;
+	}
 
-  function check_math_captcha($result, $entered_result)
-   {
-    if(intval($result) == intval($entered_result)) return true;
-    else return false;
-   }
- }
+	function check_math_captcha($result, $entered_result) {
+		if (intval($result) == intval($entered_result)) return true;
+		else return false;
+	}
+}
 ?>

--- a/modules/captcha/captcha.php
+++ b/modules/captcha/captcha.php
@@ -80,7 +80,11 @@ class Captcha
       if(preg_match('/\.png$/i', $bg)) $im = ImageCreateFromPNG($backgrounds_folder.$bg);
       elseif(preg_match('/\.gif$/i', $bg)) $im = ImageCreateFromGIF($backgrounds_folder.$bg);
       else $im = ImageCreateFromJPEG($backgrounds_folder.$bg);
-      if(function_exists('imagerotate') && mt_rand(0,1)==1) $im = imagerotate($im, 180, 0);
+      if (function_exists('imageflip') && mt_rand(0, 5) % 2 == 0) {
+       $flipConsts = [IMG_FLIP_HORIZONTAL, IMG_FLIP_VERTICAL, IMG_FLIP_BOTH];
+       $flipper = mt_rand(0, 2);
+       imageflip($im, $flipConsts[$flipper]);
+      }
      }
     // if not, create an empty image:
     else

--- a/modules/captcha/captcha_image.php
+++ b/modules/captcha/captcha_image.php
@@ -1,14 +1,11 @@
 <?php
-ini_set('error_reporting','E_ALL');
+ini_set('error_reporting', 'E_ALL');
 session_start();
 require('captcha.php');
 $captcha = new Captcha();
-if(isset($_SESSION['captcha_session']))
- {
-  $captcha->generate_image($_SESSION['captcha_session'],'backgrounds/','fonts/');
- }
-else
- {
-  $captcha->generate_dummy_image();
- }
+if (isset($_SESSION['captcha_session'])) {
+	$captcha->generate_image($_SESSION['captcha_session'], 'backgrounds/', 'fonts/');
+} else {
+	$captcha->generate_dummy_image();
+}
 ?>


### PR DESCRIPTION
As [reported in the project forum](https://mylittleforum.net/forum/index.php?id=14994) and documented in issue #658 it is possible, that the function `imagerotate` does not work with the rotation angle of exactly 180° *in **very** rare cases*. Leaving aside the fact that the concept of captchas is absolutely out of date and thinking about the current solution in `modules/captcha/captcha.php` it is …

1. … IMHO not ideal to rely on a chance of 0 or 1 to try to rotate the image or not and …
2. … to rotate the background exclusively with an angle of 180° or not (0°)

Thatswhy I replaced the rotation (with `imagerotate`) with a mirroring with the function `imageflip`, which provides three modes (horizontal, vertical and both at once) to generate the resulting image. The new solution decides if to rotate or not with a random number in the range from 0 to 5 and the criterion of the number being even or odd. The mode of the mirroring is set with a further random number in the range from 0 to 2, that selects the mode to use from an array. See therefor 972e6da9dbf4a3e3cb49fc2844bd311909a9f0ba.

Furthermore I reformatted the files `modules/captcha/captcha.php` and `modules/captcha/captcha_image.php`. See therefor de7923c31cbd5774567516573b6feb3cb9d336d3 and 1e9d98c5d6c54e8c4752178b010216c8bca1160f