### PR TITLE
Set the character encoding with the proper PHP function 

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -19,7 +19,8 @@ function connect_db($host, $user, $pw, $db) {
 		raise_error('mysql_connect', mysqli_connect_error());
 	$connid = @mysqli_connect($host, $user, $pw) or raise_error('mysql_connect', mysqli_connect_error());
 	@mysqli_select_db($connid, $db) or raise_error('mysql_select_db', mysqli_error($connid));
-	@mysqli_query($connid, 'SET NAMES utf8mb4');
+	mysqli_set_charset($connid, "utf8mb4");
+	@mysqli_query($connid, 'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci');
 	return $connid;
 }
 


### PR DESCRIPTION
Until now we set the character set encoding of the database connection with the query `SET NAMES utf8mb4`. As [the manual page of the function `mysqli_set_names`](https://www.php.net/manual/de/mysqli.set-charset.php) states, is the use of the function preferred over the use of the above mentioned query for this purpose because the function changes more than only the charset of the connection itself.

**But** the function does not set a collation for the connection (defines the sorting of ordered query results). When the collation is not explicitely set to a defined value, the default value configured on the specific server is used instead.

This is described [in](https://www.php.net/manual/de/mysqli.set-charset.php#122858) [a](https://www.php.net/manual/de/mysqli.set-charset.php#121067) [few](https://www.php.net/manual/de/mysqli.set-charset.php#121647) of the user comments on the bottom of the manual page for the function `mysqli_set_charset` wich also provide a method to solve the problem. To unify this, we have keep the query and have to enhance it with setting a specific collation.

The selected collation might be replaced later if and when we encounter a problem with the sorting of results.

See also #693 