### PR TITLE
Further PR for fixes in the upgrade script

### DIFF
--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -521,6 +521,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$update['items'][] = 'includes/bookmark.inc.php';
 				// #489, #501, #505, #507, #594
 				$update['items'][] = 'includes/contact.inc.php';
+				// #705
+				$update['items'][] = 'includes/delete_cookie.inc.php';
 				// #505, #509, #536, #585, #611
 				$update['items'][] = 'includes/entry.inc.php';
 				// #377, #390, #410, #467, #478, #498, #499, #512, #519. #520, #524, #526,
@@ -917,6 +919,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.99.0')
 		$update['items'][] = 'includes/bookmark.inc.php';
 		// #489, #501, #505, #507, #594
 		$update['items'][] = 'includes/contact.inc.php';
+		// #705
+		$update['items'][] = 'includes/delete_cookie.inc.php';
 		// #505, #509, #536, #585, #611
 		$update['items'][] = 'includes/entry.inc.php';
 		// #467, #478, #498, #499, #512, #519. #520, #524, #526, #528, #540, #554, #571,
@@ -1256,6 +1260,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.99.1')
 		$update['items'][] = 'includes/bookmark.inc.php';
 		// #489, #501, #505, #507, #594
 		$update['items'][] = 'includes/contact.inc.php';
+		// #705
+		$update['items'][] = 'includes/delete_cookie.inc.php';
 		// #505, #509, #536, #585, #611
 		$update['items'][] = 'includes/entry.inc.php';
 		// #467, #478, #498, #499, #512, #519. #520, #524, #526, #528, #540, #554, #571,
@@ -1616,6 +1622,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.99.2',
 		$update['items'][] = 'includes/bookmark.inc.php';
 		// #507, #594
 		$update['items'][] = 'includes/contact.inc.php';
+		// #705
+		$update['items'][] = 'includes/delete_cookie.inc.php';
 		// #509, #536, #585, #611
 		$update['items'][] = 'includes/entry.inc.php';
 		// #512, #519. #520, #524, #526, #528, #540, #554, #571, #587, #589, #593, #594,
@@ -1925,11 +1933,16 @@ if (empty($update['errors']) && in_array($settings['version'], array('20220508.1
 	// collect the file and directory names to upgrade
 	if (empty($update['errors'])) {
 		$update['items'][] = 'includes/admin.inc.php';
+		$update['items'][] = 'includes/auto_login.inc.php';
+		$update['items'][] = 'includes/delete_cookie.inc.php';
 		$update['items'][] = 'includes/entry.inc.php';
 		$update['items'][] = 'includes/functions.inc.php';
 		$update['items'][] = 'includes/index.inc.php';
+		$update['items'][] = 'includes/login.inc.php';
+		$update['items'][] = 'includes/main.inc.php';
 		$update['items'][] = 'includes/posting.inc.php';
 		$update['items'][] = 'includes/search.inc.php';
+		$update['items'][] = 'includes/thread.inc.php';
 		$update['items'][] = 'includes/upload_image.inc.php';
 		$update['items'][] = 'includes/user.inc.php';
 		
@@ -2131,11 +2144,16 @@ if (empty($update['errors']) && in_array($settings['version'], array('20220517.1
 	// collect the file and directory names to upgrade
 	if (empty($update['errors'])) {
 		$update['items'][] = 'includes/admin.inc.php';
+		$update['items'][] = 'includes/auto_login.inc.php';
+		$update['items'][] = 'includes/delete_cookie.inc.php';
 		$update['items'][] = 'includes/entry.inc.php';
 		$update['items'][] = 'includes/functions.inc.php';
 		$update['items'][] = 'includes/index.inc.php';
+		$update['items'][] = 'includes/login.inc.php';
+		$update['items'][] = 'includes/main.inc.php';
 		$update['items'][] = 'includes/posting.inc.php';
 		$update['items'][] = 'includes/search.inc.php';
+		$update['items'][] = 'includes/thread.inc.php';
 		$update['items'][] = 'includes/upload_image.inc.php';
 		$update['items'][] = 'includes/user.inc.php';
 		
@@ -2337,8 +2355,16 @@ if (empty($update['errors']) && in_array($settings['version'], array('20220803.1
 	// collect the file and directory names to upgrade
 	if (empty($update['errors'])) {
 		$update['items'][] = 'includes/admin.inc.php';
+		$update['items'][] = 'includes/auto_login.inc.php';
+		$update['items'][] = 'includes/delete_cookie.inc.php';
+		$update['items'][] = 'includes/entry.inc.php';
 		$update['items'][] = 'includes/functions.inc.php';
+		$update['items'][] = 'includes/index.inc.php';
+		$update['items'][] = 'includes/login.inc.php';
+		$update['items'][] = 'includes/main.inc.php';
 		$update['items'][] = 'includes/posting.inc.php';
+		$update['items'][] = 'includes/search.inc.php';
+		$update['items'][] = 'includes/thread.inc.php';
 		$update['items'][] = 'includes/user.inc.php';
 		
 		$update['items'][] = 'index.php';

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -532,7 +532,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				// #472, #521, #554, #611
 				$update['items'][] = 'includes/index.inc.php';
 				// #390
-				$update['items'][] = 'includes/insert_flash.inc.php (remove)';
+				$update['delete'][] = 'includes/insert_flash.inc.php (remove)';
 				// #377, #390, #550, #575, #578, #589
 				$update['items'][] = 'includes/js_defaults.inc.php';
 				// #526, #550, #554, #594
@@ -668,7 +668,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				// #637
 				$update['items'][] = 'themes/default/main.tpl';
 				// #390
-				$update['items'][] = 'themes/default/insert_flash.inc.tpl (remove)';
+				$update['delete'][] = 'themes/default/insert_flash.inc.tpl (remove)';
 				// #390
 				$update['items'][] = 'themes/default/js_config.ini';
 				// #390, #461, #477, #530, #531, #533, #534, #537, #538, #598, #608, #612,

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1512,7 +1512,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.99.2',
 				FROM information_schema.STATISTICS 
 				WHERE TABLE_SCHEMA LIKE '". $db_settings['database'] ."' AND
 				TABLE_NAME LIKE '" . $db_settings['userdata_table'] ."' AND 
-				INDEX_NAME LIKE IN('user_type', 'user_name');");
+				INDEX_NAME IN('user_type', 'user_name');");
 				if (mysqli_num_rows($rObsoleteIndexes) > 0) {
 					while ($row  = mysqli_fetch_assoc($rObsoleteIndexes)) {
 						if (!@mysqli_query($connid, "DROP INDEX ". $row['obsolete_key'] ." ON " . $db_settings['userdata_table'] .";")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);


### PR DESCRIPTION
In a former state the WHERE-clause for the search for the possibly existing obsolete indexes `user_type` and `user_name` in the userdata table worked with `LIKE 'user_%'`. Because this could theoretically affect further indexes, beginning with `user_`, that could be created by a forum operator, we changed the syntax to search the exact names with `IN('user_type', 'user_name')`. Doing this I forgot to remove the keyword `LIKE` from the WHERE-clause. So the first fix in this pull request is to remove LIKE from the query.