### PR TITLE
Fix for database errors, caused by missing columns in the select-part of queries

### DIFF
--- a/includes/main.inc.php
+++ b/includes/main.inc.php
@@ -246,7 +246,7 @@ if ($show_spam) {
 	$spam_totals = " AS spam_list ON spam_list.id = ft.id WHERE spam_list.id IS NULL";
 }
 if ($categories == false) {
-	$total_postings_category = "";		
+	$total_postings_category = "";
 } else {
 	// there are categories
 	$total_postings_category = " AND category IN (" . $category_ids_query . ")";		


### PR DESCRIPTION
When installing a forum and upgrading it to the current code for testing purposes, the main overview page quitted with an error message, that told me, a query failed because of the use of a column in the ORDER BY clause, that was not part of the SELECT part of the query. The first error affected the query to select the IDs of the opening postings (use of `sticky` and `time`) and the second the data to create the thread trees (use of `time`).

It seems to be an issue of the configuration of the database server (in my cae MySQL 8.0). It's also possible that this is an unintended consequence of the database optimisations or a combination of both. This cannot be determined in a hurry. I hope, I found every case.

The first issue was solved by adding the columns `sticky` and `time` to the query. The query works in a test with a few postings in two threads.

The second was a bit tricky because the affected column was in use in the query but was reformatted with `UNIX_TIMESTAMP(ft.time) AS time`. This needed to introduce a new column in the query result with `time as rawtime` to use this alias for the ORDER BY clause.