### PR TITLE
Rework of the database table mlf2_banlists

### DIFF
--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -429,8 +429,24 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					
 					
 					// changes in the banlist table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['banlists_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
+					mysqli_query($connid, "RENAME TABLE `". $db_settings['banlists_table'] ."`
+					TO `". $db_settings['banlists_table'] ."_old`;");
+					
+					mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."` (`name` varchar(255) NOT NULL, `list` text NOT NULL, PRIMARY KEY (`name`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
+					
+					mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+					FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'ips';");
+					
+					mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+					FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'user_agents';");
+					
+					mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+					FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'words';");
+					
+					mysqli_query($connid, "DROP TABLE IF EXISTS `". $db_settings['banlists_table'] ."_old`;");
 					
 					
 					// changes in the bookmarks table
@@ -854,8 +870,24 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.99.0')
 				
 				
 				// changes in the banlist table
-				mysqli_query($connid, "ALTER TABLE `" . $db_settings['banlists_table'] . "`
-				CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
+				mysqli_query($connid, "RENAME TABLE `". $db_settings['banlists_table'] ."`
+				TO `". $db_settings['banlists_table'] ."_old`;");
+				
+				mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."` (`name` varchar(255) NOT NULL, `list` text NOT NULL, PRIMARY KEY (`name`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'ips';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'user_agents';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'words';");
+				
+				mysqli_query($connid, "DROP TABLE IF EXISTS `". $db_settings['banlists_table'] ."_old`;");
 				
 				
 				// changes in the bookmarks table
@@ -1247,6 +1279,27 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.99.1')
 				mysqli_query($connid, "UPDATE `" . $db_settings['forum_table'] . " SET`
 				`edited` = NULL
 				WHERE `edited` = '0000-00-00 00:00:00';");
+				
+				
+				// changes in the banlist table
+				mysqli_query($connid, "RENAME TABLE `". $db_settings['banlists_table'] ."`
+				TO `". $db_settings['banlists_table'] ."_old`;");
+				
+				mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."` (`name` varchar(255) NOT NULL, `list` text NOT NULL, PRIMARY KEY (`name`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'ips';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'user_agents';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'words';");
+				
+				mysqli_query($connid, "DROP TABLE IF EXISTS `". $db_settings['banlists_table'] ."_old`;");
 				
 				
 				// changes in the bookmark tags table
@@ -1643,6 +1696,27 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.99.2',
 				WHERE `edited` = '0000-00-00 00:00:00';");
 				
 				
+				// changes in the banlist table
+				mysqli_query($connid, "RENAME TABLE `". $db_settings['banlists_table'] ."`
+				TO `". $db_settings['banlists_table'] ."_old`;");
+				
+				mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."` (`name` varchar(255) NOT NULL, `list` text NOT NULL, PRIMARY KEY (`name`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'ips';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'user_agents';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'words';");
+				
+				mysqli_query($connid, "DROP TABLE IF EXISTS `". $db_settings['banlists_table'] ."_old`;");
+				
+				
 				// changes in the bookmark tags table
 				mysqli_query($connid, "ALTER TABLE `" . $db_settings['bookmark_tags_table'] . "`
 				CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
@@ -1997,6 +2071,27 @@ if (empty($update['errors']) && in_array($settings['version'], array('20220508.1
 				WHERE `edited` = '0000-00-00 00:00:00';");
 				
 				
+				// changes in the banlist table
+				mysqli_query($connid, "RENAME TABLE `". $db_settings['banlists_table'] ."`
+				TO `". $db_settings['banlists_table'] ."_old`;");
+				
+				mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."` (`name` varchar(255) NOT NULL, `list` text NOT NULL, PRIMARY KEY (`name`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'ips';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'user_agents';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'words';");
+				
+				mysqli_query($connid, "DROP TABLE IF EXISTS `". $db_settings['banlists_table'] ."_old`;");
+				
+				
 				// changes in the bookmark tags table
 				mysqli_query($connid, "ALTER TABLE `" . $db_settings['bookmark_tags_table'] . "`
 				CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
@@ -2233,6 +2328,27 @@ if (empty($update['errors']) && in_array($settings['version'], array('20220517.1
 				mysqli_query($connid, "UPDATE `" . $db_settings['forum_table'] . " SET`
 				`edited` = NULL
 				WHERE `edited` = '0000-00-00 00:00:00';");
+				
+				
+				// changes in the banlist table
+				mysqli_query($connid, "RENAME TABLE `". $db_settings['banlists_table'] ."`
+				TO `". $db_settings['banlists_table'] ."_old`;");
+				
+				mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."` (`name` varchar(255) NOT NULL, `list` text NOT NULL, PRIMARY KEY (`name`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'ips';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'user_agents';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'words';");
+				
+				mysqli_query($connid, "DROP TABLE IF EXISTS `". $db_settings['banlists_table'] ."_old`;");
 				
 				
 				// changes in the bookmark tags table
@@ -2473,6 +2589,27 @@ if (empty($update['errors']) && in_array($settings['version'], array('20220803.1
 				WHERE `edited` = '0000-00-00 00:00:00';");
 				
 				
+				// changes in the banlist table
+				mysqli_query($connid, "RENAME TABLE `". $db_settings['banlists_table'] ."`
+				TO `". $db_settings['banlists_table'] ."_old`;");
+				
+				mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."` (`name` varchar(255) NOT NULL, `list` text NOT NULL, PRIMARY KEY (`name`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'ips';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'user_agents';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'words';");
+				
+				mysqli_query($connid, "DROP TABLE IF EXISTS `". $db_settings['banlists_table'] ."_old`;");
+				
+				
 				// changes in the bookmark tags table
 				mysqli_query($connid, "ALTER TABLE `" . $db_settings['bookmark_tags_table'] . "`
 				CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
@@ -2624,6 +2761,27 @@ if (empty($update['errors']) && in_array($settings['version'], array('20240308.1
 				mysqli_query($connid, "UPDATE `" . $db_settings['forum_table'] . " SET`
 				`edited` = NULL
 				WHERE `edited` = '0000-00-00 00:00:00';");
+				
+				
+				// changes in the banlist table
+				mysqli_query($connid, "RENAME TABLE `". $db_settings['banlists_table'] ."`
+				TO `". $db_settings['banlists_table'] ."_old`;");
+				
+				mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."` (`name` varchar(255) NOT NULL, `list` text NOT NULL, PRIMARY KEY (`name`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'ips';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'user_agents';");
+				
+				mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
+				SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+				FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'words';");
+				
+				mysqli_query($connid, "DROP TABLE IF EXISTS `". $db_settings['banlists_table'] ."_old`;");
 				
 				mysqli_commit($connid);
 			} catch (mysqli_sql_exception $exception) {


### PR DESCRIPTION
The table was defined without a primary key. This can cause the multiple presence of the rows under special circumstances (in example after a reimport of the data into the table). This in turn can mean that not all existing values can be managed and utilised.

With the change the old table will be renamed, a new table with a PK will be created and the existing data will be imported into the new table.  With the use of one `INSERT` with `GROUP_CONCAT()` of the data it is ensured, that the content of the column `list` of every row with the specified value for the column `name` gets part of only one row with the specified `name` value. The last step is to drop the old table from the database.

**Known issue**: when entries are part of multiple rows in the old table, they will be there multiple times in **one row** of the new table.

Example:

~~~
old table:
==========

name  | list
------------
words | foo
      | bar
      | baz
------------
words | foo
      | baz

new table:
==========

name  | list
------------
words | foo
      | foo
      | bar
      | baz
      | baz
~~~

Ths does not affect the feature in itself because a check for a banned value will find the value anyway. It is therefore not immediately necessary to de-duplicate the values. It can be done with another pull request.

This fixes #710.