### PR TITLE
Put forgotten column for ORDER BY clause into the SELECT-section of the query

### DIFF
--- a/includes/index.inc.php
+++ b/includes/index.inc.php
@@ -85,7 +85,7 @@ if ($categories == false) {
 }
 
 $display_page_threads = 
-	"SELECT DISTINCT ft.tid, ft.sticky, ft.time FROM ".$db_settings['forum_table']." AS ft 
+	"SELECT DISTINCT ft.tid, ft.sticky, ft.time, ft.last_reply FROM ".$db_settings['forum_table']." AS ft 
 	LEFT JOIN (SELECT id, tid FROM " . $db_settings['forum_table'] . " INNER JOIN " . $db_settings['akismet_rating_table'] . " ON " . $db_settings['forum_table'] . ".id = " . $db_settings['akismet_rating_table'] . ".eid WHERE " . $db_settings['akismet_rating_table'] . ".spam = 1 UNION SELECT id, tid FROM " . $db_settings['forum_table'] . " INNER JOIN " . $db_settings['b8_rating_table'] . " ON " . $db_settings['forum_table'] . ".id = " . $db_settings['b8_rating_table'] .".eid WHERE " . $db_settings['b8_rating_table'] . ".spam = 1) spam_list ON spam_list.tid = ft.id 
 	WHERE ft.pid = 0";  
 


### PR DESCRIPTION
Add the column `mlf2_entries.last_reply` to the select-block of the query to get all thread-ids to be able to order the result by that column.

fixes #731