### PR TITLE
Collect the table names from the existing entries in $db_settings

### DIFF
--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -67,6 +67,12 @@ function write_new_version_string_2_db($connid, $new_version) {
 	return $updated_version;
 }
 
+if (!function_exists('str_ends_with')) {
+	function str_ends_with($str, $end) {
+		return (@substr_compare($str, $end, -mb_strlen($end)) == 0);
+	}
+}
+
 
 // check version:
 if (!file_exists('config/VERSION')) $update['errors'][] = 'Error in line '.__LINE__.': Missing the file config/VERSION. Load it up from your script package (config/VERSION) before proceeding.';

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -69,10 +69,9 @@ function write_new_version_string_2_db($connid, $new_version) {
 
 if (!function_exists('str_ends_with')) {
 	function str_ends_with($str, $end) {
-		return (@substr_compare($str, $end, -mb_strlen($end)) == 0);
+		return (@substr_compare($str, $end, -mb_strlen($end)) == 0) ? true : false;
 	}
 }
-
 
 // check version:
 if (!file_exists('config/VERSION')) $update['errors'][] = 'Error in line '.__LINE__.': Missing the file config/VERSION. Load it up from your script package (config/VERSION) before proceeding.';


### PR DESCRIPTION
For changing the database engine of tables to InnoDB we collect the affected table names with a query. For this purpose I wrote a list with all possible table names in an `IN()`. Problem was, that I listed *every* possible table name in its representation in the array `$db_settings` even the table and with it its element in the array does not exist in the current version, that should be upgraded. With a correspondingly configured error level, an error was generated due to the non-existent array elements in `$db_settings`.

I now collect the *existing* table name entries in `$db_settings` in a loop and inserting the resulting imploded string to the query. This ensures to not using non existing table names.