### PR TITLE
Unify the common CSS rules for the subject link under the class `.subject`

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -723,7 +723,10 @@ html[dir="rtl"] .currentreplynew
                          { background-position: 100% -1458px; }
 
 a.internal,
-a.internal:link          { padding-left:18px; color:#0000cc; text-decoration:none; background:url(images/bg_sprite_1.png) no-repeat 0 -148px; }
+a.internal:link          { padding-inline-start:18px; color:#0000cc; text-decoration:none; background:url(images/bg_sprite_1.png) no-repeat 0 -148px; }
+html[dir="rtl"] a.internal,
+html[dir="rtl"] a.internal:link
+                         { background-position-x: 100%; }
 a.internal:focus,
 a.internal:hover         { color:#0000ff; text-decoration:underline; }
 a.internal:active        { color:#ff0000; }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -616,109 +616,78 @@ ul#uploadlist            { list-style: none; margin: 0; padding: 0; max-width: 1
 .confirm-selection .item { margin: 0 0 0.25em 0; }
 .confirm-selection .info { font-weight: bold; margin: 0; }
 
+/* subject links: */
+span.subject,
+a.subject,
+a.subject:link           { text-decoration: none; font-weight: bold; }
+a.subject,
+a.subject:link           { color: #0000cc; }
+a.subject:visited        { color: #007; }
+a.subject:focus,
+a.subject:hover          { color: #0000ff; text-decoration: underline; }
+a.subject:active         { color: #ff0000; }
 /* thread links: */
 a.thread,
-a.thread:link            { padding-inline-start:18px; color:#0000cc; text-decoration:none; font-weight:bold; background:url(images/bg_sprite_1.png) no-repeat 0 -148px; }
+a.thread:link            { padding-inline-start: 18px; background: url(images/bg_sprite_1.png) no-repeat 0 -148px; }
 html[dir="rtl"] a.thread,
 html[dir="rtl"] a.thread:link
-                         { background:url(images/bg_sprite_1.png) no-repeat 100% -148px; }
-a.thread:visited         { color:#007; }
-a.thread:focus,
-a.thread:hover           { color:#0000ff; text-decoration:underline; }
-a.thread:active          { color:#ff0000; }
+                         { background-position-x: 100%; }
 /* sticky threads: */
 a.thread-sticky,
-a.thread-sticky:link     { padding-inline-start:18px; color:#0000cc; text-decoration:none; font-weight:bold; background:url(images/bg_sprite_1.png) no-repeat 0 -250px; }
+a.thread-sticky:link     { padding-inline-start: 18px; background: url(images/bg_sprite_1.png) no-repeat 0 -250px; }
 html[dir="rtl"] a.thread-sticky,
 html[dir="rtl"] a.thread-sticky:link
-                         { background:url(images/bg_sprite_1.png) no-repeat 100% -250px; }
-a.thread-sticky:visited  { color:#007; }
-a.thread-sticky:focus,
-a.thread-sticky:hover    { color:#0000ff; text-decoration:underline; }
-a.thread-sticky:active   { color:#ff0000; }
+                         { background-position-x: 100%; }
 /* sticky and locked threads: */
 a.thread-sticky-locked,
 a.thread-sticky-locked:link
-                         { padding-inline-start:18px; color:#0000cc; text-decoration:none; font-weight:bold; background:url(images/bg_sprite_1.png) no-repeat 0 -1210px; }
+                         { padding-inline-start: 18px; background: url(images/bg_sprite_1.png) no-repeat 0 -1210px; }
 html[dir="rtl"] a.thread-sticky-locked,
 html[dir="rtl"] a.thread-sticky-locked:link
-                         { background:url(images/bg_sprite_1.png) no-repeat 100% -1210px; }
-a.thread-sticky-locked:visited  { color:#007; }
-a.thread-sticky-locked:focus,
-a.thread-sticky-locked:hover    { color:#0000ff; text-decoration:underline; }
-a.thread-sticky-locked:active   { color:#ff0000; }
+                         { background-position-x: 100%; }
 /* locked threads: */
 a.thread-locked,
-a.thread-locked:link     { padding-inline-start:18px; color:#0000cc; text-decoration:none; font-weight:bold; background:url(images/bg_sprite_1.png) no-repeat 0 -1109px; }
+a.thread-locked:link     { padding-inline-start:18px; background:url(images/bg_sprite_1.png) no-repeat 0 -1109px; }
 html[dir="rtl"] a.thread-locked,
 html[dir="rtl"] a.thread-locked:link
-                         { background:url(images/bg_sprite_1.png) no-repeat 100% -1109px; }
-a.thread-locked:visited  { color:#007; }
-a.thread-locked:focus,
-a.thread-locked:hover    { color:#0000ff; text-decoration:underline; }
-a.thread-locked:active   { color:#ff0000; }
+                         { background-position-x: 100%; }
 /* new threads: */
 a.threadnew-sticky,
-a.threadnew-sticky:link  { padding-inline-start:18px; color:#0000cc; text-decoration:none; font-weight:bold; background:url(images/bg_sprite_1.png) no-repeat 0 -300px; }
+a.threadnew-sticky:link  { padding-inline-start:18px; background:url(images/bg_sprite_1.png) no-repeat 0 -300px; }
 html[dir="rtl"] a.threadnew-sticky,
 html[dir="rtl"] a.threadnew-sticky:link
-                         { background:url(images/bg_sprite_1.png) no-repeat 100% -300px; }
-a.threadnew-sticky:visited
-                         { color:#007; }
-a.threadnew-sticky:focus,
-a.threadnew-sticky:hover { color:#0000ff; text-decoration:underline; }
-a.threadnew-sticky:active
-                         { color:#ff0000; }
+                         { background-position-x: 100%; }
 /* new sticky and locked threads: */
 a.threadnew-sticky-locked,
 a.threadnew-sticky-locked:link
-                         { padding-inline-start:18px; color:#0000cc; text-decoration:none; font-weight:bold; background:url(images/bg_sprite_1.png) no-repeat 0 -1260px; }
+                         { padding-inline-start:18px; background:url(images/bg_sprite_1.png) no-repeat 0 -1260px; }
 html[dir="rtl"] a.threadnew-sticky-locked,
 html[dir="rtl"] a.threadnew-sticky-locked:link
-                         { background:url(images/bg_sprite_1.png) no-repeat 100% -1260px; }
-a.threadnew-sticky-locked:visited { color:#007; }
-a.threadnew-sticky-locked:focus,
-a.threadnew-sticky-locked:hover   { color:#0000ff; text-decoration:underline; }
-a.threadnew-sticky-locked:active  { color:#ff0000; }
+                         { background-position-x: 100%; }
 /* new locked threads: */
 a.threadnew-locked,
-a.threadnew-locked:link    { padding-inline-start:18px; color:#0000cc; text-decoration:none; font-weight:bold; background:url(images/bg_sprite_1.png) no-repeat 0 -1160px; }
+a.threadnew-locked:link    { padding-inline-start:18px; background:url(images/bg_sprite_1.png) no-repeat 0 -1160px; }
 html[dir="rtl"] a.threadnew-locked,
 html[dir="rtl"] a.threadnew-locked:link
-                           { background:url(images/bg_sprite_1.png) no-repeat 100% -1160px; }
-a.threadnew-locked:visited { color:#007; }
-a.threadnew-locked:focus,
-a.threadnew-locked:hover   { color:#0000ff; text-decoration:underline; }
-a.threadnew-locked:active  { color:#ff0000; }
+                           { background-position-x: 100%; }
 /* new threads: */
 a.threadnew,
-a.threadnew:link         { padding-inline-start:18px; color:#0000cc; text-decoration:none; font-weight:bold; background:url(images/bg_sprite_1.png) no-repeat 0 -198px; }
+a.threadnew:link         { padding-inline-start:18px; background:url(images/bg_sprite_1.png) no-repeat 0 -198px; }
 html[dir="rtl"] a.threadnew,
 html[dir="rtl"] a.threadnew:link
-                         { background:url(images/bg_sprite_1.png) no-repeat 100% -198px; }
-a.threadnew:visited      { color:#007; }
-a.threadnew:focus,
-a.threadnew:hover        { color:#0000ff; text-decoration:underline; }
-a.threadnew:active       { color:#ff0000; }
+                         { background-position-x: 100%; }
 /* replies: */
 a.reply,
-a.reply:link             { padding-inline-start:16px; color:#0000cc; text-decoration:none; font-weight:normal; background:url(images/bg_sprite_1.png) no-repeat 0 -348px; }
+a.reply:link             { padding-inline-start:16px; font-weight:normal; background:url(images/bg_sprite_1.png) no-repeat 0 -348px; }
 html[dir="rtl"] a.reply,
 html[dir="rtl"] a.reply:link
-                         { background:url(images/bg_sprite_1.png) no-repeat 100% -1408px; }
-a.reply:visited          { color:#007; }
-a.reply:focus,
-a.reply:hover            { color:#0000ff; text-decoration:underline; }
-a.reply:active           { color:#ff0000; }
+                         { background-position: 100% -1408px; }
+/* unread replies */
 a.replynew,
-a.replynew:link          { padding-inline-start:16px; color:#0000cc; text-decoration:none; font-weight:normal; background:url(images/bg_sprite_1.png) no-repeat 0 -398px; }
+a.replynew:link          { padding-inline-start:16px; font-weight:normal; background:url(images/bg_sprite_1.png) no-repeat 0 -398px; }
 html[dir="rtl"] a.replynew,
 html[dir="rtl"] a.replynew:link
-                         { background:url(images/bg_sprite_1.png) no-repeat 100% -1458px; }
-a.replynew:visited       { color:#007; }
-a.replynew:focus,
-a.replynew:hover         { color:#0000ff; text-decoration:underline; }
-a.replynew:active        { color:#ff0000; }
+                         { background-position: 100% -1458px; }
 
 a.read,
 a.read:link,

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -704,18 +704,23 @@ ul.thread li > .metadata { text-wrap: nowrap; }
 main:not(:has(table#threadlist)) ul.thread li > a::after
                          { content: " - "; }
 
-.currentthread           { padding-inline-start:18px; color:#ff0000; font-weight:bold; background:url(images/bg_sprite_1.png) no-repeat 0 -148px; }
+.currentthread,
+.currentthreadnew,
+.currentreply,
+.currentreplynew         { color:#ff0000; font-weight:bold; }
+
+.currentthread           { padding-inline-start:18px; background:url(images/bg_sprite_1.png) no-repeat 0 -148px; }
 html[dir="rtl"] .currentthread
-                         { background: url(images/bg_sprite_1.png) no-repeat 100% -148px; }
-.currentthreadnew        { padding-inline-start:18px; color:#ff0000; font-weight:bold; background:url(images/bg_sprite_1.png) no-repeat 0 -198px; }
+                         { background-position-x: 100%; }
+.currentthreadnew        { padding-inline-start:18px; background:url(images/bg_sprite_1.png) no-repeat 0 -198px; }
 html[dir="rtl"] .currentthreadnew
-                         { background: url(images/bg_sprite_1.png) no-repeat 100% -198px; }
-.currentreply            { padding-inline-start:16px; color:#ff0000; font-weight:bold; background:url(images/bg_sprite_1.png) no-repeat 0 -348px; }
+                         { background-position-x: 100%; }
+.currentreply            { padding-inline-start:16px; background:url(images/bg_sprite_1.png) no-repeat 0 -348px; }
 html[dir="rtl"] .currentreply
-                         { background: url(images/bg_sprite_1.png) no-repeat 100% -1408px; }
-.currentreplynew         { padding-inline-start:16px; color:#ff0000; font-weight:bold; background:url(images/bg_sprite_1.png) no-repeat 0 -398px; }
+                         { background-position: 100% -1408px; }
+.currentreplynew         { padding-inline-start:16px; background:url(images/bg_sprite_1.png) no-repeat 0 -398px; }
 html[dir="rtl"] .currentreplynew
-                         { background: url(images/bg_sprite_1.png) no-repeat 100% -1458px; }
+                         { background-position: 100% -1458px; }
 
 a.internal,
 a.internal:link          { padding-left:18px; color:#0000cc; text-decoration:none; background:url(images/bg_sprite_1.png) no-repeat 0 -148px; }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -430,7 +430,7 @@ html[dir="rtl"] .currentreply{background-position:100% -1408px}
 .currentreplynew{padding-inline-start:16px;background:url(images/bg_sprite_1.png) no-repeat 0 -398px}
 html[dir="rtl"] .currentreplynew{background-position:100% -1458px}
 a.internal,a.internal:link{padding-inline-start:18px;color:#00c;text-decoration:none;background:url(images/bg_sprite_1.png) no-repeat 0 -148px}
-html[dir="rtl"] a.internal,html[dir="rtl"] a.internal:link{background:url(images/bg_sprite_1.png) no-repeat 100% -148px}
+html[dir="rtl"] a.internal,html[dir="rtl"] a.internal:link{background-position-x:100%}
 a.internal:focus,a.internal:hover{color:#00f;text-decoration:underline}
 a.internal:active{color:red}
 ul.thread{margin:0 0 1.5em;padding:0;list-style-type:none;max-width:100%!important}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -390,56 +390,31 @@ ul#uploadlist{list-style:none;margin:0;padding:0;max-width:100%;display:flex;fle
 .confirm-selection li{min-height:2.5em;margin:0 0 .25em 0;padding:.25em .5em;border-bottom:1px solid #bacbdf}
 .confirm-selection .item{margin:0 0 .25em 0}
 .confirm-selection .info{font-weight:bold;margin:0}
-a.thread,a.thread:link{padding-inline-start:18px;color:#00c;text-decoration:none;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -148px}
-html[dir="rtl"] a.thread,html[dir="rtl"] a.thread:link{background:url(images/bg_sprite_1.png) no-repeat 100% -148px}
-a.thread:visited{color:#007}
-a.thread:focus,a.thread:hover{color:#00f;text-decoration:underline}
-a.thread:active{color:red}
-a.thread-sticky,a.thread-sticky:link{padding-inline-start:18px;color:#00c;text-decoration:none;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -250px}
-html[dir="rtl"] a.thread-sticky,html[dir="rtl"] a.thread-sticky:link{background:url(images/bg_sprite_1.png) no-repeat 100% -250px}
-a.thread-sticky:visited{color:#007}
-a.thread-sticky:focus,a.thread-sticky:hover{color:#00f;text-decoration:underline}
-a.thread-sticky:active{color:red}
-a.thread-sticky-locked,a.thread-sticky-locked:link{padding-inline-start:18px;color:#00c;text-decoration:none;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -1210px}
-html[dir="rtl"] a.thread-sticky-locked,html[dir="rtl"] a.thread-sticky-locked:link{background:url(images/bg_sprite_1.png) no-repeat 100% -1210px}
-a.thread-sticky-locked:visited{color:#007}
-a.thread-sticky-locked:focus,a.thread-sticky-locked:hover{color:#00f;text-decoration:underline}
-a.thread-sticky-locked:active{color:red}
-a.thread-locked,a.thread-locked:link{padding-inline-start:18px;color:#00c;text-decoration:none;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -1109px}
-html[dir="rtl"] a.thread-locked,html[dir="rtl"] a.thread-locked:link{background:url(images/bg_sprite_1.png) no-repeat 100% -1109px}
-a.thread-locked:visited{color:#007}
-a.thread-locked:focus,a.thread-locked:hover{color:#00f;text-decoration:underline}
-a.thread-locked:active{color:red}
-a.threadnew-sticky,a.threadnew-sticky:link{padding-inline-start:18px;color:#00c;text-decoration:none;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -300px}
-html[dir="rtl"] a.threadnew-sticky,html[dir="rtl"] a.threadnew-sticky:link{background:url(images/bg_sprite_1.png) no-repeat 100% -300px}
-a.threadnew-sticky:visited{color:#007}
-a.threadnew-sticky:focus,a.threadnew-sticky:hover{color:#00f;text-decoration:underline}
-a.threadnew-sticky:active{color:red}
-a.threadnew-sticky-locked,a.threadnew-sticky-locked:link{padding-inline-start:18px;color:#00c;text-decoration:none;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -1260px}
-html[dir="rtl"] a.threadnew-sticky-locked,html[dir="rtl"] a.threadnew-sticky-locked:link{background:url(images/bg_sprite_1.png) no-repeat 100% -1260px}
-a.threadnew-sticky-locked:visited{color:#007}
-a.threadnew-sticky-locked:focus,a.threadnew-sticky-locked:hover{color:#00f;text-decoration:underline}
-a.threadnew-sticky-locked:active{color:red}
-a.threadnew-locked,a.threadnew-locked:link{padding-inline-start:18px;color:#00c;text-decoration:none;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -1160px}
-html[dir="rtl"] a.threadnew-locked,html[dir="rtl"] a.threadnew-locked:link{background:url(images/bg_sprite_1.png) no-repeat 100% -1160px}
-a.threadnew-locked:visited{color:#007}
-a.threadnew-locked:focus,a.threadnew-locked:hover{color:#00f;text-decoration:underline}
-a.threadnew-locked:active{color:red}
-a.threadnew,a.threadnew:link{padding-inline-start:18px;color:#00c;text-decoration:none;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -198px}
-html[dir="rtl"] a.threadnew,html[dir="rtl"] a.threadnew:link{background:url(images/bg_sprite_1.png) no-repeat 100% -198px}
-a.threadnew:visited{color:#007}
-a.threadnew:focus,a.threadnew:hover{color:#00f;text-decoration:underline}
-a.threadnew:active{color:red}
-a.reply,a.reply:link{padding-inline-start:16px;color:#00c;text-decoration:none;font-weight:400;background:url(images/bg_sprite_1.png) no-repeat 0 -348px}
-html[dir="rtl"] a.reply,html[dir="rtl"] a.reply:link{background:url(images/bg_sprite_1.png) no-repeat 100% -1408px}
-a.reply:visited{color:#007}
-a.reply:focus,a.reply:hover{color:#00f;text-decoration:underline}
-a.reply:active{color:red}
-a.replynew,a.replynew:link{padding-inline-start:16px;color:#00c;text-decoration:none;font-weight:400;background:url(images/bg_sprite_1.png) no-repeat 0 -398px}
-html[dir="rtl"] a.replynew,html[dir="rtl"] a.replynew:link{background:url(images/bg_sprite_1.png) no-repeat 100% -1458px}
-a.replynew:visited{color:#007}
-a.replynew:focus,a.replynew:hover{color:#00f;text-decoration:underline}
-a.replynew:active{color:red}
+span.subject,a.subject,a.subject:link{text-decoration:none;font-weight:bold}
+a.subject,a.subject:link{color:#00c}
+a.subject:visited{color:#007}
+a.subject:focus,a.subject:hover{color:#00f;text-decoration:underline}
+a.subject:active{color:red}
+a.thread,a.thread:link{padding-inline-start:18px;background:url(images/bg_sprite_1.png) no-repeat 0 -148px}
+html[dir="rtl"] a.thread,html[dir="rtl"] a.thread:link{background-position-x:100%}
+a.thread-sticky,a.thread-sticky:link{padding-inline-start:18px;background:url(images/bg_sprite_1.png) no-repeat 0 -250px}
+html[dir="rtl"] a.thread-sticky,html[dir="rtl"] a.thread-sticky:link{background-position-x:100%}
+a.thread-sticky-locked,a.thread-sticky-locked:link{padding-inline-start:18px;background:url(images/bg_sprite_1.png) no-repeat 0 -1210px}
+html[dir="rtl"] a.thread-sticky-locked,html[dir="rtl"] a.thread-sticky-locked:link{background-position-x:100%}
+a.thread-locked,a.thread-locked:link{padding-inline-start:18px;background:url(images/bg_sprite_1.png) no-repeat 0 -1109px}
+html[dir="rtl"] a.thread-locked,html[dir="rtl"] a.thread-locked:link{background-position-x:100%}
+a.threadnew-sticky,a.threadnew-sticky:link{padding-inline-start:18px;background:url(images/bg_sprite_1.png) no-repeat 0 -300px}
+html[dir="rtl"] a.threadnew-sticky,html[dir="rtl"] a.threadnew-sticky:link{background-position-x:100%}
+a.threadnew-sticky-locked,a.threadnew-sticky-locked:link{padding-inline-start:18px;background:url(images/bg_sprite_1.png) no-repeat 0 -1260px}
+html[dir="rtl"] a.threadnew-sticky-locked,html[dir="rtl"] a.threadnew-sticky-locked:link{background-position-x:100%}
+a.threadnew-locked,a.threadnew-locked:link{padding-inline-start:18px;background:url(images/bg_sprite_1.png) no-repeat 0 -1160px}
+html[dir="rtl"] a.threadnew-locked,html[dir="rtl"] a.threadnew-locked:link{background-position-x:100%}
+a.threadnew,a.threadnew:link{padding-inline-start:18px;background:url(images/bg_sprite_1.png) no-repeat 0 -198px}
+html[dir="rtl"] a.threadnew,html[dir="rtl"] a.threadnew:link{background-position-x:100%}
+a.reply,a.reply:link{padding-inline-start:16px;font-weight:normal;background:url(images/bg_sprite_1.png) no-repeat 0 -348px}
+html[dir="rtl"] a.reply,html[dir="rtl"] a.reply:link{background-position:100% -1408px}
+a.replynew,a.replynew:link{padding-inline-start:16px;font-weight:normal;background:url(images/bg_sprite_1.png) no-repeat 0 -398px}
+html[dir="rtl"] a.replynew,html[dir="rtl"] a.replynew:link{background-position:100% -1458px}
 a.read,a.read:link,a.read:visited,#latest-postings li a span.read{color:#007}
 a.read:focus,a.read:hover{color:#00f}
 a.read:active{color:red}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -420,14 +420,15 @@ a.read:focus,a.read:hover{color:#00f}
 a.read:active{color:red}
 ul.thread li > a,ul.thread li .currentreply,ul.thread li > .metadata{text-wrap:nowrap}
 main:not(:has(table#threadlist)) ul.thread li > a::after{content:" - "}
-.currentthread{padding-inline-start:18px;color:red;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -148px}
-html[dir="rtl"] .currentthread{background:url(images/bg_sprite_1.png) no-repeat 100% -148px}
-.currentthreadnew{padding-inline-start:18px;color:red;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -198px}
-html[dir="rtl"] .currentthreadnew{background:url(images/bg_sprite_1.png) no-repeat 100% -198px}
-.currentreply{padding-inline-start:16px;color:red;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -348px}
-html[dir="rtl"] .currentreply{background:url(images/bg_sprite_1.png) no-repeat 100% -1408px}
-.currentreplynew{padding-inline-start:16px;color:red;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat 0 -398px}
-html[dir="rtl"] .currentreplynew{background:url(images/bg_sprite_1.png) no-repeat 100% -1458px}
+.currentthread,.currentthreadnew,.currentreply,.currentreplynew{color:#ff0000;font-weight:bold}
+.currentthread{padding-inline-start:18px;background:url(images/bg_sprite_1.png) no-repeat 0 -148px}
+html[dir="rtl"] .currentthread{background-position-x:100%}
+.currentthreadnew{padding-inline-start:18px;background:url(images/bg_sprite_1.png) no-repeat 0 -198px}
+html[dir="rtl"] .currentthreadnew{background-position-x:100%}
+.currentreply{padding-inline-start:16px;background:url(images/bg_sprite_1.png) no-repeat 0 -348px}
+html[dir="rtl"] .currentreply{background-position:100% -1408px}
+.currentreplynew{padding-inline-start:16px;background:url(images/bg_sprite_1.png) no-repeat 0 -398px}
+html[dir="rtl"] .currentreplynew{background-position:100% -1458px}
 a.internal,a.internal:link{padding-inline-start:18px;color:#00c;text-decoration:none;background:url(images/bg_sprite_1.png) no-repeat 0 -148px}
 html[dir="rtl"] a.internal,html[dir="rtl"] a.internal:link{background:url(images/bg_sprite_1.png) no-repeat 100% -148px}
 a.internal:focus,a.internal:hover{color:#00f;text-decoration:underline}


### PR DESCRIPTION
The CSS-rules for the many different states of a subject link [^1] contains many identical, repeated definitions. Because of the new introduced class `.subject` *which is present in every case*, it is now possible to move these rules to this class and to deduplicate them in the definition blocks for the state specific classes.
  
[^1]: i.e. `thread`, `thread-locked`, `thread-sticky`, `thread-sticky-locked` and so on