### PR TITLE
ISO-timestamps in the subject line for report spam and flag ham pages

### DIFF
--- a/includes/posting.inc.php
+++ b/includes/posting.inc.php
@@ -1618,7 +1618,7 @@ switch ($action) {
 		break;
 	case 'report_spam':
 		$id = intval($_GET['report_spam']);
-		$result = mysqli_query($connid, "SELECT tid, pid, UNIX_TIMESTAMP(time + INTERVAL " . $time_difference . " MINUTE) AS disp_time, 
+		$result = mysqli_query($connid, "SELECT tid, pid, UNIX_TIMESTAMP(time) AS time, UNIX_TIMESTAMP(time + INTERVAL " . $time_difference . " MINUTE) AS disp_time, 
 		                              user_id, name, subject, category, 
 									  " . $db_settings['akismet_rating_table'] . ".spam AS akismet_spam, spam_check_status, 
 									  " . $db_settings['b8_rating_table'] . ".spam AS b8_spam, training_type 
@@ -1642,7 +1642,7 @@ switch ($action) {
 				$smarty->assign('pid', intval($field['pid']));
 				$smarty->assign('name', htmlspecialchars($field['name']));
 				$smarty->assign('subject', htmlspecialchars($field['subject']));
-				$smarty->assign('disp_time', htmlspecialchars($field['disp_time']));
+				$smarty->assign('ISO_time', htmlspecialchars(format_time('YYYY-MM-dd HH:mm:ss', $field['time'])));
 				$smarty->assign('formated_time', htmlspecialchars(format_time($lang['time_format_full'], $field['disp_time'])));
 				$smarty->assign('akismet_spam', intval($field['akismet_spam']));
 				$smarty->assign('akismet_spam_check_status', intval($field['spam_check_status']));

--- a/includes/posting.inc.php
+++ b/includes/posting.inc.php
@@ -1746,7 +1746,7 @@ switch ($action) {
 		break;
 	case 'flag_ham':
 		$id = intval($_GET['flag_ham']);
-		$result = mysqli_query($connid, "SELECT tid, pid, UNIX_TIMESTAMP(time + INTERVAL " . $time_difference . " MINUTE) AS disp_time, 
+		$result = mysqli_query($connid, "SELECT tid, pid, UNIX_TIMESTAMP(time) AS time, UNIX_TIMESTAMP(time + INTERVAL " . $time_difference . " MINUTE) AS disp_time, 
 		                              user_id, name, subject, category,
 									  " . $db_settings['akismet_rating_table'] . ".spam AS akismet_spam, spam_check_status, 
 									  " . $db_settings['b8_rating_table'] . ".spam AS b8_spam, training_type 
@@ -1771,7 +1771,7 @@ switch ($action) {
 				$smarty->assign('pid', intval($field['pid']));
 				$smarty->assign('name', htmlspecialchars($field['name']));
 				$smarty->assign('subject', htmlspecialchars($field['subject']));
-				$smarty->assign('disp_time', htmlspecialchars($field['disp_time']));
+				$smarty->assign('ISO_time', htmlspecialchars(format_time('YYYY-MM-dd HH:mm:ss', $field['time'])));
 				$smarty->assign('formated_time', htmlspecialchars(format_time($lang['time_format_full'], $field['disp_time'])));
 				$smarty->assign('akismet_spam', intval($field['akismet_spam']));
 				$smarty->assign('akismet_spam_check_status', intval($field['spam_check_status']));

--- a/themes/default/subtemplates/posting_flag_ham.inc.tpl
+++ b/themes/default/subtemplates/posting_flag_ham.inc.tpl
@@ -10,7 +10,7 @@
 {else}
  <p class="notice caution">{#caution#}</p>
  <p>{#flag_ham_warning#}</p>
- <p><strong>{$subject}</strong> - <strong>{$name}</strong>, {$formated_time}</p>
+ <p><span class="subject">{$subject}</span> - <span class="metadata"><span class="author-name">{$name}</span>, <span class="tail"><time datetime="{$ISO_time}">{$formated_time}</time></span></span></p>
  <form action="index.php" method="post" accept-charset="{#charset#}">
   <input type="hidden" name="mode" value="posting" />
   <input type="hidden" name="id" value="{$id}" />

--- a/themes/default/subtemplates/posting_report_spam.inc.tpl
+++ b/themes/default/subtemplates/posting_report_spam.inc.tpl
@@ -13,7 +13,7 @@
 {if $akismet_spam_check_status==2} <p>{#spamcheck_akismet_timeout_error#}</p>{/if}
 {if $akismet_spam_check_status==3} <p>{#spamcheck_akismet_api_error#}</p>{/if}
 
- <p><span class="subject">{$subject}</span> - <span class="metadata"><span class="author-name">{$name}</span>, <span class="tail"><time datetime="">{$formated_time}</time></span></span></p>
+ <p><span class="subject">{$subject}</span> - <span class="metadata"><span class="author-name">{$name}</span>, <span class="tail"><time datetime="{$ISO_time}">{$formated_time}</time></span></span></p>
  <form action="index.php" method="post" accept-charset="{#charset#}">
   <input type="hidden" name="mode" value="posting" />
   <input type="hidden" name="id" value="{$id}" />


### PR DESCRIPTION
With PR #746 we added `time` elements for the timestamp in the subject lines. I forgot to add the ISO formatted datetime to the `datetime` attribute in the `time` element in the report spam template. Furthermore I completely forgot to add the new HTML-structure of the subject line to the flag ham template. Both is solved with the changes in this PR.