### PR TITLE
Make WebP images appear in the uploaded-images browsing view

### DIFF
--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -954,7 +954,7 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 		$browse_images = (isset($_GET['browse_images']) && $_GET['browse_images'] > 0) ? intval($_GET['browse_images']) : 1;
 		$handle = opendir($uploaded_images_path);
 		while ($file = readdir($handle)) {
-			if (preg_match('/\.(gif|png|jpg|svg|webp)$/i', $file)) {
+			if (preg_match('/\.(gif|png|jpe?g|svg|webp)$/i', $file)) {
 				$images[] = $file;
 			}
 		}

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -127,7 +127,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		if ($browse_images < 1) $browse_images = 1;
 		$handle = opendir($uploaded_images_path);
 		while ($file = readdir($handle)) {
-			if (preg_match('/\.jpe?g$/i', $file) || preg_match('/\.webp$/i', $file) || preg_match('/\.png$/i', $file) || preg_match('/\.gif$/i', $file)) {
+			if (preg_match('/\.(gif|png|jpe?g|svg|webp)$/i', $file)) {
 				$images[] = $file;
 			}
 		}


### PR DESCRIPTION
Added *.webp and also *.svg to file types, that are listed in the browsing view. The script is yet not prepared to allow uploads of SVGs but also the image browsing view in the administration area allows SVG and we should handle it the same way everywhere.

The file types are now checked in one regular expression instead of using dedicated expressions for each individual file type.

This fixes #766 and superseeds #768