### PR TITLE
Complete rework of the template of the upload popup

### DIFF
--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -73,7 +73,10 @@ h1 {
 img.delete    { max-width:300px; max-height:150px; }
 img.uploaded  { max-width:300px; max-height:110px; /*cursor:pointer;*/ }
 .deletelink   { font-size:11px; padding-left:13px; background:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/bg_sprite_3.png) no-repeat 0 -47px; }
-.small        { font-size:11px; line-height:16px; }
+.small        {
+  font-size:11px;
+  line-height:16px;
+}
 code          { font-family:"courier new", courier; color:#000080; }
 a:link        { color:#0000cc; text-decoration: none; }
 a:visited     { color:#0000cc; text-decoration: none; }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -201,14 +201,6 @@ function insertCode(image_url) {
  </div>
 {/if}
 {elseif $delete_confirm}
-<form id="uploadform" action="index.php" method="post" accept-charset="{#charset#}">
-<div>
-<input type="hidden" name="mode" value="upload_image" />
-<input type="hidden" name="delete" value="{$delete}" />
-{if $current}<input type="hidden" name="current" value="{$current}" />{/if}
-<input type="submit" name="delete_confirm" value="{#delete_image_button#}" />
-</div>
-</form>
  <div id="header">
   <div id="nav-1"><a href="index.php?mode=upload_image&amp;browse_images={$current|default:'1'}">{#back#}</a></div>
  </div>
@@ -219,6 +211,14 @@ function insertCode(image_url) {
   <ul id="imgtab" class="shrinked">
    <li><img src="images/uploaded/{$delete}" alt="{$delete}" /></li>
   </ul>
+  <form id="uploadform" action="index.php" method="post" accept-charset="{#charset#}">
+   <input type="hidden" name="mode" value="upload_image" />
+   <input type="hidden" name="delete" value="{$delete}" />
+{if $current}   <input type="hidden" name="current" value="{$current}" />{/if}
+   <div>
+    <button name="delete_confirm" value="{#delete_image_button#}">{#delete_image_button#}</button>
+   </div>
+  </form>
  </div>
 {else}
  <div id="wrapper">

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -82,10 +82,22 @@ code {
   font-family:"courier new", courier, monospace;
   color:#000080;
 }
-a:link        { color:#0000cc; text-decoration: none; }
-a:visited     { color:#0000cc; text-decoration: none; }
-a:hover       { color:#0000ff; text-decoration: underline; }
-a:active      { color:#ff0000; text-decoration: none; }
+a:link {
+  color:#0000cc;
+  text-decoration: none;
+}
+a:visited {
+  color:#0000cc;
+  text-decoration: none;
+}
+a:hover {
+  color:#0000ff;
+  text-decoration: underline;
+}
+a:active {
+  color:#ff0000;
+  text-decoration: none;
+}
 form > div:not(:last-child) {
   margin-block-end: .75em;
 }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -208,6 +208,10 @@ function insertCode(image_url) {
       <img src="images/uploaded/{$images[nr]}" title="{#insert_image#}" alt="{#insert_image#}" />
      </button>
     </div>
+    <div class="insert-desc">
+     <p>{#insert_image_exp_no_js#}</p>
+     <p><code>[img]images/uploaded/{$images[nr]}[/img]</code></p>
+    </div>
 {if $admin || $mod}    <div><a class="deletelink" href="index.php?mode=upload_image&amp;delete={$images[nr]}&amp;current={$current}">{#delete#}</a></div>
 {/if}
    </li>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -83,16 +83,16 @@ code {
   color:#000080;
 }
 a {
-  color:#0000cc;
+  color:#00c;
   text-decoration: none;
 }
 a:focus,
 a:hover {
-  color:#0000ff;
+  color:#00f;
   text-decoration: underline;
 }
 a:active {
-  color:#ff0000;
+  color:#f00;
   text-decoration: none;
 }
 form > div:not(:last-child) {

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -7,7 +7,6 @@
   <style type="text/css">
 {literal}
 <!--
-img           { border:none; }
 *,
 ::before,
 ::after {
@@ -70,8 +69,6 @@ h1 {
   color:green;
   background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/tick.png);
 }
-img.delete    { max-width:300px; max-height:150px; }
-img.uploaded  { max-width:300px; max-height:110px; /*cursor:pointer;*/ }
 .deletelink {
   font-size:11px;
   padding-left:13px;

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -107,6 +107,8 @@ img {
 #imgtab img {
   max-width: 100%;
   margin-inline: auto;
+}
+#imgtab:not(.shrinked) img {
   cursor: pointer;
 }
 #imgtab.shrinked img {

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -77,7 +77,7 @@ img.uploaded  { max-width:300px; max-height:110px; /*cursor:pointer;*/ }
   font-size: 0.86em;
 }
 code {
-  font-family:"courier new", courier;
+  font-family:"courier new", courier, monospace;
   color:#000080;
 }
 a:link        { color:#0000cc; text-decoration: none; }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -90,6 +90,7 @@ a:visited {
   color:#0000cc;
   text-decoration: none;
 }
+a:focus,
 a:hover {
   color:#0000ff;
   text-decoration: underline;

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -70,10 +70,11 @@ h1 {
   background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/tick.png);
 }
 .deletelink {
-  font-size:11px;
   padding-left:13px;
   background:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/bg_sprite_3.png) no-repeat 0 -47px;
 }
+.insert-desc,
+.deletelink,
 .small {
   font-size: 0.82em;
 }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -127,7 +127,6 @@ img {
 -->
 {/literal}
   </style>
-  <script type="text/javascript">{literal}/* <![CDATA[ */
 function insertCode(image_url) {
  	if (opener && opener.mlfBBCodeButton) {
 		var bbcodeButton = opener.mlfBBCodeButton;
@@ -138,8 +137,8 @@ function insertCode(image_url) {
 		txtarea.insertTextRange( txtarea.getSelection() + "[img]" + image_url + "[/img]" );
 	}
 	//self.close();
+  <script type="text/javascript">{literal}
 }
-/* ]]> */{/literal}</script>
 window.addEventListener('DOMContentLoaded', function() {
   if (document.querySelector('div.insert-desc')) {
     const descriptors = document.querySelectorAll('div.insert-desc');
@@ -150,6 +149,7 @@ window.addEventListener('DOMContentLoaded', function() {
     });
   }
 });
+{/literal}</script>
  </head>
  <body>
 {if $form}

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -89,11 +89,11 @@ a {
 a:focus,
 a:hover {
   color:#00f;
-  text-decoration: underline;
+  text-decoration: underline dotted 9% #45f;
 }
 a:active {
   color:#f00;
-  text-decoration: none;
+  text-decoration: underline solid 7% #d00;
 }
 form > div:not(:last-child) {
   margin-block-end: .75em;

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -41,7 +41,7 @@ body > * {
   margin:0;
   padding:0;
 }
-#wrapper {
+main {
   margin-inline: 0;
   margin-block: 0.5em;
 }
@@ -175,7 +175,7 @@ window.addEventListener('DOMContentLoaded', function() {
  <div id="header">
   <h1>{#upload_image_hl#}</h1>
  </div>
- <div id="wrapper">
+ <main>
 {if $errors}
   <div class="caution">
    <h2>{#error_headline#}</h2>
@@ -197,12 +197,12 @@ window.addEventListener('DOMContentLoaded', function() {
    </div>
   </form>
   <p class="small"><a href="index.php?mode=upload_image&amp;browse_images=1">{#browse_uploaded_images#}</a></p>
- </div>
+ </main>
 {elseif $uploaded_file}
  <div id="header">
   <h1>{#upload_image_hl#}</h1>
  </div>
- <div id="wrapper">
+ <main>
   <div class="ok">
    <h2>{#upload_successful#}</h2>
   </div>
@@ -221,14 +221,14 @@ window.addEventListener('DOMContentLoaded', function() {
   </ul>
 {if $image_downsized}  <p class="small">{$smarty.config.image_downsized|replace:"[width]":$new_width|replace:"[height]":$new_height|replace:"[filesize]":$new_filesize}</p>{/if}
   <p class="small"><a href="index.php?mode=upload_image&amp;browse_images=1">{#browse_uploaded_images#}</a></p>
- </div>
+ </main>
 {elseif $browse_images}
  <div id="header">
   <div id="nav-1"><a href="index.php?mode=upload_image">{#back#}</a></div>
   <div id="nav-2">{if $previous}[ <a href="index.php?mode=upload_image&amp;browse_images={$previous}" title="{#previous_page_link_title#}">&laquo;</a> ]{/if}{if $previous && next} {/if}{if $next}[ <a href="index.php?mode=upload_image&amp;browse_images={$next}" title="{#next_page_link_title#}">&raquo;</a> ]{/if}</div>
  </div>
 {if $images}
- <div id="wrapper">
+ <main>
   <ul id="imgtab">
 {section name=nr loop=$images start=$start max=$images_per_page}
    <li>
@@ -246,17 +246,17 @@ window.addEventListener('DOMContentLoaded', function() {
    </li>
 {/section}
   </ul>
- </div>
+ </main>
 {else}
- <div id="wrapper">
+ <main>
   <p>{#no_images#}</p>
- </div>
+ </main>
 {/if}
 {elseif $delete_confirm}
  <div id="header">
   <div id="nav-1"><a href="index.php?mode=upload_image&amp;browse_images={$current|default:'1'}">{#back#}</a></div>
  </div>
- <div id="wrapper">
+ <main>
   <div class="caution">
    <h2>{#delete_image_confirm#}</h2>
   </div>
@@ -271,13 +271,13 @@ window.addEventListener('DOMContentLoaded', function() {
     <button name="delete_confirm" value="{#delete_image_button#}">{#delete_image_button#}</button>
    </div>
   </form>
- </div>
+ </main>
 {else}
- <div id="wrapper">
+ <main>
   <div class="caution">
    <h2>{#image_upload_not_enabled#}</h2>
   </div>
- </div>
+ </main>
 {/if}
 </body>
 </html>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -137,7 +137,7 @@ function insertCode(image_url) {
 		txtarea.insertTextRange( txtarea.getSelection() + "[img]" + image_url + "[/img]" );
 	}
 	//self.close();
-  <script type="text/javascript">{literal}
+  <script>{literal}
 }
 window.addEventListener('DOMContentLoaded', function() {
   if (document.querySelector('div.insert-desc')) {

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -34,7 +34,6 @@ h1 {
   font-size: 1.2em;
   font-weight: bold;
 }
-p             { font-family: verdana, arial, sans-serif; font-size: 13px; line-height: 19px; }
 .caution      { padding: 0px 0px 0px 20px; color: red; font-weight: bold; background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/caution.png); background-repeat:no-repeat; background-position: left; }
 .ok           { padding: 0px 0px 0px 20px; font-weight:bold; color:red; background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/tick.png); background-repeat:no-repeat; background-position: left; }
 img.delete    { max-width:300px; max-height:150px; }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -151,6 +151,9 @@ button {
   border: none;
   padding: 0;
 }
+.invisible {
+  visibility: hidden;
+}
 {/literal}
   </style>
   <script>{literal}
@@ -176,6 +179,14 @@ function insertCode() {
 window.addEventListener('DOMContentLoaded', function() {
   if (document.querySelector('#imgtab button')) {
     document.querySelector('#imgtab').addEventListener('click', insertCode);
+  }
+  if (document.querySelector('button[name="upload_img"]')) {
+    document.querySelector('button[name="upload_img"]').addEventListener('click', function() {
+      const throbber = document.getElementById('throbber-submit');
+      if (throbber.classList.contains('invisible')) {
+        throbber.classList.remove('invisible');
+      }
+    });
   }
   if (document.querySelector('div.insert-desc')) {
     const descriptors = document.querySelectorAll('div.insert-desc');
@@ -210,8 +221,8 @@ window.addEventListener('DOMContentLoaded', function() {
     <input type="file" name="probe" size="17" />
    </div>
    <div class="buttonbar">
-    <button value="{#upload_image_button#}" onclick="document.getElementById('throbber-submit').style.visibility='visible'">{#upload_image_button#}</button>
-    <img id="throbber-submit" style="visibility:hidden;" src="{$THEMES_DIR}/{$theme}/images/throbber_submit.gif" alt="" width="16" height="16" />
+    <button name="upload_img" value="{#upload_image_button#}">{#upload_image_button#}</button>
+    <img id="throbber-submit" class="invisible" src="{$THEMES_DIR}/{$theme}/images/throbber_submit.gif" alt="" width="16" height="16" />
    </div>
   </form>
   <p class="small"><a href="index.php?mode=upload_image&amp;browse_images=1">{#browse_uploaded_images#}</a></p>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -74,7 +74,7 @@ img.delete    { max-width:300px; max-height:150px; }
 img.uploaded  { max-width:300px; max-height:110px; /*cursor:pointer;*/ }
 .deletelink   { font-size:11px; padding-left:13px; background:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/bg_sprite_3.png) no-repeat 0 -47px; }
 .small        {
-  font-size:11px;
+  font-size: 0.86em;
 }
 code          { font-family:"courier new", courier; color:#000080; }
 a:link        { color:#0000cc; text-decoration: none; }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -187,7 +187,6 @@ window.addEventListener('DOMContentLoaded', function() {
   <div class="ok">
    <h2>{#upload_successful#}</h2>
   </div>
-{if $image_downsized}<p class="small">{$smarty.config.image_downsized|replace:"[width]":$new_width|replace:"[height]":$new_height|replace:"[filesize]":$new_filesize}</p>{/if}
   <ul id="imgtab" class="shrinked">
    <li>
     <div>
@@ -201,6 +200,7 @@ window.addEventListener('DOMContentLoaded', function() {
     </div>
    </li>
   </ul>
+{if $image_downsized}  <p class="small">{$smarty.config.image_downsized|replace:"[width]":$new_width|replace:"[height]":$new_height|replace:"[filesize]":$new_filesize}</p>{/if}
  </div>
 <script type="text/javascript">/* <![CDATA[ */ insertCode('images/uploaded/{$uploaded_file}'); /* ]]> */</script>
 {elseif $browse_images}

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -154,10 +154,10 @@ window.onresize = getMaxWidth;
  </div>
 <script type="text/javascript">/* <![CDATA[ */ insertCode('images/uploaded/{$uploaded_file}'); /* ]]> */</script>
 {elseif $browse_images}
-<div id="header">
-<div id="nav-1"><a href="index.php?mode=upload_image">{#back#}</a></div>
-<div id="nav-2">{if $previous}[ <a href="index.php?mode=upload_image&amp;browse_images={$previous}" title="{#previous_page_link_title#}">&laquo;</a> ]{/if}{if $previous && next} {/if}{if $next}[ <a href="index.php?mode=upload_image&amp;browse_images={$next}" title="{#next_page_link_title#}">&raquo;</a> ]{/if}</div>
-</div>
+ <div id="header">
+  <div id="nav-1"><a href="index.php?mode=upload_image">{#back#}</a></div>
+  <div id="nav-2">{if $previous}[ <a href="index.php?mode=upload_image&amp;browse_images={$previous}" title="{#previous_page_link_title#}">&laquo;</a> ]{/if}{if $previous && next} {/if}{if $next}[ <a href="index.php?mode=upload_image&amp;browse_images={$next}" title="{#next_page_link_title#}">&raquo;</a> ]{/if}</div>
+ </div>
 {if $images}
 <table id="imgtab" border="0" cellpadding="5" cellspacing="1">
  <div id="wrapper">
@@ -175,9 +175,6 @@ window.onresize = getMaxWidth;
  </div>
 {/if}
 {elseif $delete_confirm}
-<div id="header">
-<div id="nav-1"><a href="index.php?mode=upload_image&amp;browse_images={$current|default:'1'}">{#back#}</a></div>
-</div>
 <p><img class="delete" src="images/uploaded/{$delete}" alt="{$delete}" /></p>
 <form id="uploadform" action="index.php" method="post" accept-charset="{#charset#}">
 <div>
@@ -187,6 +184,9 @@ window.onresize = getMaxWidth;
 <input type="submit" name="delete_confirm" value="{#delete_image_button#}" />
 </div>
 </form>
+ <div id="header">
+  <div id="nav-1"><a href="index.php?mode=upload_image&amp;browse_images={$current|default:'1'}">{#back#}</a></div>
+ </div>
  <div id="wrapper">
   <div class="caution">
    <h2>{#delete_image_confirm#}</h2>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -37,10 +37,11 @@ h1 {
   font-size: 1.2em;
   font-weight: bold;
 }
+}
 .caution {
   padding: 0px 0px 0px 20px;
-  color: red;
   font-weight: bold;
+  color: #cc0000;
   background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/caution.png);
   background-repeat:no-repeat;
   background-position: left;
@@ -48,7 +49,7 @@ h1 {
 .ok {
   padding: 0px 0px 0px 20px;
   font-weight:bold;
-  color:red;
+  color:green;
   background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/tick.png);
   background-repeat:no-repeat;
   background-position: left;

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -8,7 +8,6 @@
 {literal}
 <!--
 img           { border:none; }
-#wrapper      { margin:0; padding:20px; }
 body {
   color: #000;
   background: #fff;
@@ -18,6 +17,10 @@ body {
   font-size: 1em;
   font-size: 1rem;
   line-height: 1.5;
+}
+body > * {
+  padding-block: 0;
+  padding-inline: 0.5em;
 }
 #header {
   margin: 0;

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -33,6 +33,10 @@ body > * {
   border-bottom: 1px solid #bacbdf;
   display: flex;
   justify-content: space-between;
+  position: sticky;
+  top: 0;
+  left: 0;
+  width: 100%;
 }
 #header > * {
   margin:0;

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -38,6 +38,10 @@ body > * {
   margin:0;
   padding:0;
 }
+#wrapper {
+  margin-inline: 0;
+  margin-block: 0.5em;
+}
 h1 {
   font-size: 1em;
   font-weight: bold;
@@ -111,8 +115,8 @@ window.onresize = getMaxWidth;
  </head>
  <body>
 {if $form}
-<div id="wrapper">
 <h1>{#upload_image_hl#}</h1>
+ <div id="wrapper">
 {if $errors}
   <div class="caution">
    <h2>{#error_headline#}</h2>
@@ -131,10 +135,10 @@ window.onresize = getMaxWidth;
 </div>
 </form>
 <p class="small"><a href="index.php?mode=upload_image&amp;browse_images=1">{#browse_uploaded_images#}</a></p>
-</div>
+ </div>
 {elseif $uploaded_file}
-<div id="wrapper">
 <h1>{#upload_image_hl#}</h1>
+ <div id="wrapper">
   <div class="ok">
    <h2>{#upload_successful#}</h2>
   </div>
@@ -143,7 +147,7 @@ window.onresize = getMaxWidth;
 <p><code>[img]images/uploaded/{$uploaded_file}[/img]</code></p></noscript>
 <img class="uploaded" src="images/uploaded/{$uploaded_file}" title="{#insert_image#}" {*onclick="insertCode('images/uploaded/{$uploaded_file}'); return false;" *}alt="{#insert_image#}" />
 {if $image_downsized}<p class="small">{$smarty.config.image_downsized|replace:"[width]":$new_width|replace:"[height]":$new_height|replace:"[filesize]":$new_filesize}</p>{/if}
-</div>
+ </div>
 <script type="text/javascript">/* <![CDATA[ */ insertCode('images/uploaded/{$uploaded_file}'); /* ]]> */</script>
 {elseif $browse_images}
 <div id="header">
@@ -152,6 +156,7 @@ window.onresize = getMaxWidth;
 </div>
 {if $images}
 <table id="imgtab" border="0" cellpadding="5" cellspacing="1">
+ <div id="wrapper">
 {section name=nr loop=$images start=$start max=$images_per_page}
 {cycle values="odd,even" assign=c}
 <tr class="{$c}">
@@ -159,16 +164,16 @@ window.onresize = getMaxWidth;
 </tr>
 {/section}
 </table>
+ </div>
 {else}
-<div id="wrapper">
 <p>{#no_images#}</p>
-</div>
+ <div id="wrapper">
+ </div>
 {/if}
 {elseif $delete_confirm}
 <div id="header">
 <div id="nav-1"><a href="index.php?mode=upload_image&amp;browse_images={$current|default:'1'}">{#back#}</a></div>
 </div>
-<div id="wrapper">
 <p><img class="delete" src="images/uploaded/{$delete}" alt="{$delete}" /></p>
 <form id="uploadform" action="index.php" method="post" accept-charset="{#charset#}">
 <div>
@@ -178,16 +183,17 @@ window.onresize = getMaxWidth;
 <input type="submit" name="delete_confirm" value="{#delete_image_button#}" />
 </div>
 </form>
-</div>
+ <div id="wrapper">
   <div class="caution">
    <h2>{#delete_image_confirm#}</h2>
   </div>
+ </div>
 {else}
-<div id="wrapper">
-</div>
+ <div id="wrapper">
   <div class="caution">
    <h2>{#image_upload_not_enabled#}</h2>
   </div>
+ </div>
 {/if}
 </body>
 </html>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -8,6 +8,11 @@
 {literal}
 <!--
 img           { border:none; }
+*,
+::before,
+::after {
+  box-sizing: border-box;
+}
 body {
   color: #000;
   background: #fff;

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -75,7 +75,6 @@ img.uploaded  { max-width:300px; max-height:110px; /*cursor:pointer;*/ }
 .deletelink   { font-size:11px; padding-left:13px; background:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/bg_sprite_3.png) no-repeat 0 -47px; }
 .small        {
   font-size:11px;
-  line-height:16px;
 }
 code          { font-family:"courier new", courier; color:#000080; }
 a:link        { color:#0000cc; text-decoration: none; }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -157,7 +157,7 @@ function insertCode(image_url) {
    </ul>
   </div>
 {/if}
-  <form id="uploadform" action="index.php" method="post" enctype="multipart/form-data" accept-charset="{#charset#}">
+  <form id="upload-form" action="index.php" method="post" enctype="multipart/form-data" accept-charset="{#charset#}">
    <input type="hidden" name="mode" value="upload_image" />
    <div>
     <input type="file" name="probe" size="17" />
@@ -219,7 +219,7 @@ function insertCode(image_url) {
   <ul id="imgtab" class="shrinked">
    <li><img src="images/uploaded/{$delete}" alt="{$delete}" /></li>
   </ul>
-  <form id="uploadform" action="index.php" method="post" accept-charset="{#charset#}">
+  <form id="del-upload-form" action="index.php" method="post" accept-charset="{#charset#}">
    <input type="hidden" name="mode" value="upload_image" />
    <input type="hidden" name="delete" value="{$delete}" />
 {if $current}   <input type="hidden" name="current" value="{$current}" />{/if}

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -31,8 +31,7 @@ body {
   padding:0;
 }
 h1 {
-  font-family: verdana, arial, sans-serif;
-  font-size: 18px;
+  font-size: 1.2em;
   font-weight: bold;
 }
 p             { font-family: verdana, arial, sans-serif; font-size: 13px; line-height: 19px; }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -80,8 +80,31 @@ a:link        { color:#0000cc; text-decoration: none; }
 a:visited     { color:#0000cc; text-decoration: none; }
 a:hover       { color:#0000ff; text-decoration: underline; }
 a:active      { color:#ff0000; text-decoration: none; }
-table         { width:100%; margin:5px 0 0 0; padding:0; }
-td            { text-align:center; }
+ul {
+  list-style:none;
+  margin-block:0.5em;
+  padding: 0;
+}
+#imgtab {
+  display:flex;
+  flex-direction:column;
+  gap:0.75em;
+}
+#imgtab li {
+  text-align:center;
+}
+li > div:last-child {
+  align-content:center;
+}
+img {
+  border:none;
+  display: block;
+  margin-inline: auto;
+}
+#imgtab img {
+  max-width: 100%;
+  cursor: pointer;
+}
 -->
 {/literal}
   </style>
@@ -98,24 +121,6 @@ function insertCode(image_url) {
 	//self.close();
 }
 /* ]]> */{/literal}</script>
-{if $browse_images}
-  <script type="text/javascript">{literal}/* <![CDATA[ */
-function getMaxWidth()
- {
-  if(document.getElementById('imgtab'))
-   {
-    var maxWidth = document.getElementById('imgtab').offsetWidth-20;
-    var obj=getElementsByClassName('browse');
-    for(i=0;i<obj.length;i++)
-     {
-      obj[i].style.maxWidth=maxWidth+'px';
-     }
-   }
- }
-window.onload = getMaxWidth;
-window.onresize = getMaxWidth;
-/* ]]> */{/literal}</script>
-{/if}
  </head>
  <body>
 {if $form}
@@ -163,15 +168,16 @@ window.onresize = getMaxWidth;
   <div id="nav-2">{if $previous}[ <a href="index.php?mode=upload_image&amp;browse_images={$previous}" title="{#previous_page_link_title#}">&laquo;</a> ]{/if}{if $previous && next} {/if}{if $next}[ <a href="index.php?mode=upload_image&amp;browse_images={$next}" title="{#next_page_link_title#}">&raquo;</a> ]{/if}</div>
  </div>
 {if $images}
-<table id="imgtab" border="0" cellpadding="5" cellspacing="1">
  <div id="wrapper">
+  <ul id="imgtab">
 {section name=nr loop=$images start=$start max=$images_per_page}
-{cycle values="odd,even" assign=c}
-<tr class="{$c}">
-<td><img class="browse" src="images/uploaded/{$images[nr]}" title="{#insert_image#}" onclick="insertCode('images/uploaded/{$images[nr]}'); self.close();" alt="{#insert_image#}" />{if $admin || $mod}<br /><a class="deletelink" href="index.php?mode=upload_image&amp;delete={$images[nr]}&amp;current={$current}">{#delete#}</a>{/if}</td>
-</tr>
+   <li>
+    <div><img class="browse" src="images/uploaded/{$images[nr]}" title="{#insert_image#}" onclick="insertCode('images/uploaded/{$images[nr]}'); self.close();" alt="{#insert_image#}" /></div>
+{if $admin || $mod}    <div><a class="deletelink" href="index.php?mode=upload_image&amp;delete={$images[nr]}&amp;current={$current}">{#delete#}</a></div>
+{/if}
+   </li>
 {/section}
-</table>
+  </ul>
  </div>
 {else}
 <p>{#no_images#}</p>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -201,6 +201,7 @@ window.addEventListener('DOMContentLoaded', function() {
    </li>
   </ul>
 {if $image_downsized}  <p class="small">{$smarty.config.image_downsized|replace:"[width]":$new_width|replace:"[height]":$new_height|replace:"[filesize]":$new_filesize}</p>{/if}
+  <p class="small"><a href="index.php?mode=upload_image&amp;browse_images=1">{#browse_uploaded_images#}</a></p>
  </div>
 <script type="text/javascript">/* <![CDATA[ */ insertCode('images/uploaded/{$uploaded_file}'); /* ]]> */</script>
 {elseif $browse_images}

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -72,7 +72,6 @@ h1 {
 }
 img.delete    { max-width:300px; max-height:150px; }
 img.uploaded  { max-width:300px; max-height:110px; /*cursor:pointer;*/ }
-img.browse    { max-width:320px; cursor:pointer; }
 .deletelink   { font-size:11px; padding-left:13px; background:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/bg_sprite_3.png) no-repeat 0 -47px; }
 .small        { font-size:11px; line-height:16px; }
 code          { font-family:"courier new", courier; color:#000080; }
@@ -178,7 +177,7 @@ function insertCode(image_url) {
   <ul id="imgtab">
 {section name=nr loop=$images start=$start max=$images_per_page}
    <li>
-    <div><img class="browse" src="images/uploaded/{$images[nr]}" title="{#insert_image#}" onclick="insertCode('images/uploaded/{$images[nr]}'); self.close();" alt="{#insert_image#}" /></div>
+    <div><img src="images/uploaded/{$images[nr]}" title="{#insert_image#}" onclick="insertCode('images/uploaded/{$images[nr]}'); self.close();" alt="{#insert_image#}" /></div>
 {if $admin || $mod}    <div><a class="deletelink" href="index.php?mode=upload_image&amp;delete={$images[nr]}&amp;current={$current}">{#delete#}</a></div>
 {/if}
    </li>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -74,8 +74,8 @@ h1 {
   padding-left:13px;
   background:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/bg_sprite_3.png) no-repeat 0 -47px;
 }
-.small        {
-  font-size: 0.86em;
+.small {
+  font-size: 0.82em;
 }
 code {
   font-family:"courier new", courier, monospace;

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -26,7 +26,7 @@ body > * {
   padding-block: 0;
   padding-inline: 0.5em;
 }
-#header {
+header {
   margin: 0;
   background: #f9f9f9;
   border-bottom: 1px solid #bacbdf;
@@ -37,7 +37,7 @@ body > * {
   left: 0;
   width: 100%;
 }
-#header > * {
+header > * {
   margin:0;
   padding:0;
 }
@@ -172,9 +172,9 @@ window.addEventListener('DOMContentLoaded', function() {
  </head>
  <body>
 {if $form}
- <div id="header">
+ <header>
   <h1>{#upload_image_hl#}</h1>
- </div>
+ </header>
  <main>
 {if $errors}
   <div class="caution">
@@ -199,9 +199,9 @@ window.addEventListener('DOMContentLoaded', function() {
   <p class="small"><a href="index.php?mode=upload_image&amp;browse_images=1">{#browse_uploaded_images#}</a></p>
  </main>
 {elseif $uploaded_file}
- <div id="header">
+ <header>
   <h1>{#upload_image_hl#}</h1>
- </div>
+ </header>
  <main>
   <div class="ok">
    <h2>{#upload_successful#}</h2>
@@ -223,10 +223,10 @@ window.addEventListener('DOMContentLoaded', function() {
   <p class="small"><a href="index.php?mode=upload_image&amp;browse_images=1">{#browse_uploaded_images#}</a></p>
  </main>
 {elseif $browse_images}
- <div id="header">
+ <header>
   <div id="nav-1"><a href="index.php?mode=upload_image">{#back#}</a></div>
   <div id="nav-2">{if $previous}[ <a href="index.php?mode=upload_image&amp;browse_images={$previous}" title="{#previous_page_link_title#}">&laquo;</a> ]{/if}{if $previous && next} {/if}{if $next}[ <a href="index.php?mode=upload_image&amp;browse_images={$next}" title="{#next_page_link_title#}">&raquo;</a> ]{/if}</div>
- </div>
+ </header>
 {if $images}
  <main>
   <ul id="imgtab">
@@ -253,9 +253,9 @@ window.addEventListener('DOMContentLoaded', function() {
  </main>
 {/if}
 {elseif $delete_confirm}
- <div id="header">
+ <header>
   <div id="nav-1"><a href="index.php?mode=upload_image&amp;browse_images={$current|default:'1'}">{#back#}</a></div>
- </div>
+ </header>
  <main>
   <div class="caution">
    <h2>{#delete_image_confirm#}</h2>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -8,8 +8,6 @@
 {literal}
 <!--
 img           { border:none; }
-#nav-1        { margin:0; padding:0 0 0 5px; float:left; }
-#nav-2        { margin:0; padding:0 5px 0 0; float:right; }
 #wrapper      { margin:0; padding:20px; }
 h1            { font-family: verdana, arial, sans-serif; font-size: 18px; font-weight: bold; }
 p             { font-family: verdana, arial, sans-serif; font-size: 13px; line-height: 19px; }
@@ -27,7 +25,12 @@ body {
   margin: 0;
   background: #f9f9f9;
   border-bottom: 1px solid #bacbdf;
-  height: 24px;
+  display: flex;
+  justify-content: space-between;
+}
+#header > * {
+  margin:0;
+  padding:0;
 }
 .caution      { padding: 0px 0px 0px 20px; color: red; font-weight: bold; background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/caution.png); background-repeat:no-repeat; background-position: left; }
 .ok           { padding: 0px 0px 0px 20px; font-weight:bold; color:red; background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/tick.png); background-repeat:no-repeat; background-position: left; }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -82,11 +82,7 @@ code {
   font-family:"courier new", courier, monospace;
   color:#000080;
 }
-a:link {
-  color:#0000cc;
-  text-decoration: none;
-}
-a:visited {
+a {
   color:#0000cc;
   text-decoration: none;
 }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -203,7 +203,6 @@ window.addEventListener('DOMContentLoaded', function() {
 {if $image_downsized}  <p class="small">{$smarty.config.image_downsized|replace:"[width]":$new_width|replace:"[height]":$new_height|replace:"[filesize]":$new_filesize}</p>{/if}
   <p class="small"><a href="index.php?mode=upload_image&amp;browse_images=1">{#browse_uploaded_images#}</a></p>
  </div>
-<script type="text/javascript">/* <![CDATA[ */ insertCode('images/uploaded/{$uploaded_file}'); /* ]]> */</script>
 {elseif $browse_images}
  <div id="header">
   <div id="nav-1"><a href="index.php?mode=upload_image">{#back#}</a></div>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -105,6 +105,10 @@ img {
   max-width: 100%;
   cursor: pointer;
 }
+#imgtab.shrinked img {
+  max-width: 50%;
+  height: auto;
+}
 -->
 {/literal}
   </style>
@@ -158,8 +162,10 @@ function insertCode(image_url) {
 {*<script type="text/javascript">/* <![CDATA[ */document.write('<p>{#insert_image_exp#|escape:quotes}<\/p>'); /* ]]> */</script>*}
 <noscript><p>{#insert_image_exp_no_js#}</p>
 <p><code>[img]images/uploaded/{$uploaded_file}[/img]</code></p></noscript>
-<img class="uploaded" src="images/uploaded/{$uploaded_file}" title="{#insert_image#}" {*onclick="insertCode('images/uploaded/{$uploaded_file}'); return false;" *}alt="{#insert_image#}" />
 {if $image_downsized}<p class="small">{$smarty.config.image_downsized|replace:"[width]":$new_width|replace:"[height]":$new_height|replace:"[filesize]":$new_filesize}</p>{/if}
+  <ul id="imgtab" class="shrinked">
+   <li><img src="images/uploaded/{$uploaded_file}" title="{#insert_image#}" {*onclick="insertCode('images/uploaded/{$uploaded_file}'); return false;" *}alt="{#insert_image#}" /></li>
+  </ul>
  </div>
 <script type="text/javascript">/* <![CDATA[ */ insertCode('images/uploaded/{$uploaded_file}'); /* ]]> */</script>
 {elseif $browse_images}
@@ -185,7 +191,6 @@ function insertCode(image_url) {
  </div>
 {/if}
 {elseif $delete_confirm}
-<p><img class="delete" src="images/uploaded/{$delete}" alt="{$delete}" /></p>
 <form id="uploadform" action="index.php" method="post" accept-charset="{#charset#}">
 <div>
 <input type="hidden" name="mode" value="upload_image" />
@@ -201,6 +206,9 @@ function insertCode(image_url) {
   <div class="caution">
    <h2>{#delete_image_confirm#}</h2>
   </div>
+  <ul id="imgtab" class="shrinked">
+   <li><img src="images/uploaded/{$delete}" alt="{$delete}" /></li>
+  </ul>
  </div>
 {else}
  <div id="wrapper">

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -81,6 +81,9 @@ a:link        { color:#0000cc; text-decoration: none; }
 a:visited     { color:#0000cc; text-decoration: none; }
 a:hover       { color:#0000ff; text-decoration: underline; }
 a:active      { color:#ff0000; text-decoration: none; }
+form > div:not(:last-child) {
+  margin-block-end: .75em;
+}
 ul {
   list-style:none;
   margin-block:0.5em;

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -81,9 +81,6 @@ code {
   font-family:"courier new", courier, monospace;
   color:#000080;
 }
-.insert-desc {
-  margin-block: 0.5em 0;
-}
 .insert-desc > * {
   margin-block: 0 0.25em;
 }
@@ -119,9 +116,15 @@ ul {
   max-width: 40em;
   margin-inline: auto;
 }
-#del-upload-form,
-#imgtab li {
+#del-upload-form {
   text-align:center;
+}
+#imgtab li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  align-items: center;
+  width: 100%;
 }
 li > *:last-child {
   align-content:center;

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -101,7 +101,7 @@ ul {
 #imgtab li {
   text-align:center;
 }
-li > div:last-child {
+li > *:last-child {
   align-content:center;
 }
 img {

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -182,7 +182,13 @@ function insertCode(image_url) {
 <p><code>[img]images/uploaded/{$uploaded_file}[/img]</code></p></noscript>
 {if $image_downsized}<p class="small">{$smarty.config.image_downsized|replace:"[width]":$new_width|replace:"[height]":$new_height|replace:"[filesize]":$new_filesize}</p>{/if}
   <ul id="imgtab" class="shrinked">
-   <li><img src="images/uploaded/{$uploaded_file}" title="{#insert_image#}" {*onclick="insertCode('images/uploaded/{$uploaded_file}'); return false;" *}alt="{#insert_image#}" /></li>
+   <li>
+    <div>
+     <button type="button">
+      <img src="images/uploaded/{$uploaded_file}" title="{#insert_image#}" alt="{#insert_image#}" />
+     </button>
+    </div>
+   </li>
   </ul>
  </div>
 <script type="text/javascript">/* <![CDATA[ */ insertCode('images/uploaded/{$uploaded_file}'); /* ]]> */</script>
@@ -196,7 +202,11 @@ function insertCode(image_url) {
   <ul id="imgtab">
 {section name=nr loop=$images start=$start max=$images_per_page}
    <li>
-    <div><img src="images/uploaded/{$images[nr]}" title="{#insert_image#}" onclick="insertCode('images/uploaded/{$images[nr]}'); self.close();" alt="{#insert_image#}" /></div>
+    <div>
+     <button type="button">
+      <img src="images/uploaded/{$images[nr]}" title="{#insert_image#}" alt="{#insert_image#}" />
+     </button>
+    </div>
 {if $admin || $mod}    <div><a class="deletelink" href="index.php?mode=upload_image&amp;delete={$images[nr]}&amp;current={$current}">{#delete#}</a></div>
 {/if}
    </li>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -177,9 +177,6 @@ function insertCode(image_url) {
   <div class="ok">
    <h2>{#upload_successful#}</h2>
   </div>
-{*<script type="text/javascript">/* <![CDATA[ */document.write('<p>{#insert_image_exp#|escape:quotes}<\/p>'); /* ]]> */</script>*}
-<noscript><p>{#insert_image_exp_no_js#}</p>
-<p><code>[img]images/uploaded/{$uploaded_file}[/img]</code></p></noscript>
 {if $image_downsized}<p class="small">{$smarty.config.image_downsized|replace:"[width]":$new_width|replace:"[height]":$new_height|replace:"[filesize]":$new_filesize}</p>{/if}
   <ul id="imgtab" class="shrinked">
    <li>
@@ -187,6 +184,10 @@ function insertCode(image_url) {
      <button type="button">
       <img src="images/uploaded/{$uploaded_file}" title="{#insert_image#}" alt="{#insert_image#}" />
      </button>
+    </div>
+    <div class="insert-desc">
+     <p>{#insert_image_exp_no_js#}</p>
+     <p><code>[img]images/uploaded/{$uploaded_file}[/img]</code></p>
     </div>
    </li>
   </ul>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -71,7 +71,7 @@ h1 {
 }
 .deletelink {
   padding-left:13px;
-  background:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/bg_sprite_3.png) no-repeat 0 -47px;
+  background:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/bg_sprite_3.png) no-repeat 1px -45px;
 }
 .insert-desc,
 .deletelink,

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -99,6 +99,7 @@ ul {
   flex-direction:column;
   gap:0.75em;
 }
+#del-upload-form,
 #imgtab li {
   text-align:center;
 }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -124,6 +124,9 @@ img {
   flex-wrap: wrap;
   gap: 0.3em;
 }
+button {
+  cursor: pointer;
+}
 -->
 {/literal}
   </style>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -34,8 +34,22 @@ h1 {
   font-size: 1.2em;
   font-weight: bold;
 }
-.caution      { padding: 0px 0px 0px 20px; color: red; font-weight: bold; background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/caution.png); background-repeat:no-repeat; background-position: left; }
-.ok           { padding: 0px 0px 0px 20px; font-weight:bold; color:red; background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/tick.png); background-repeat:no-repeat; background-position: left; }
+.caution {
+  padding: 0px 0px 0px 20px;
+  color: red;
+  font-weight: bold;
+  background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/caution.png);
+  background-repeat:no-repeat;
+  background-position: left;
+}
+.ok {
+  padding: 0px 0px 0px 20px;
+  font-weight:bold;
+  color:red;
+  background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/tick.png);
+  background-repeat:no-repeat;
+  background-position: left;
+}
 img.delete    { max-width:300px; max-height:150px; }
 img.uploaded  { max-width:300px; max-height:110px; /*cursor:pointer;*/ }
 img.browse    { max-width:320px; cursor:pointer; }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -82,6 +82,15 @@ code {
   font-family:"courier new", courier, monospace;
   color:#000080;
 }
+.insert-desc {
+  margin-block: 0.5em 0;
+}
+.insert-desc > * {
+  margin-block: 0 0.25em;
+}
+.insert-desc > *:last-child {
+  margin-block: 0;
+}
 a {
   color:#00c;
   text-decoration: none;

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -160,11 +160,13 @@ button {
  */
 function insertCode() {
   const clickedButton = event.target.closest('button');
-  if (clickedButton === null) return false;
+  if (clickedButton === null)
+    return false;
   const imagePath = clickedButton.querySelector('img').getAttribute('src');
   if (opener && opener.mlfBBCodeButton) {
     const bbcodeButton = opener.mlfBBCodeButton;
-    if (!bbcodeButton.canInsert()) return;
+    if (!bbcodeButton.canInsert())
+      return false;
     const buttonGroup = bbcodeButton.getButtonGroup();
     const txtarea = buttonGroup.getTextArea();
     txtarea.insertTextRange( txtarea.getSelection() + "[img]" + imagePath + "[/img]" );

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -127,17 +127,23 @@ img {
 -->
 {/literal}
   </style>
-function insertCode(image_url) {
- 	if (opener && opener.mlfBBCodeButton) {
-		var bbcodeButton = opener.mlfBBCodeButton;
-		if (!bbcodeButton.canInsert()) 
-			return;
-		var buttonGroup = bbcodeButton.getButtonGroup();	
-		var txtarea = buttonGroup.getTextArea();
-		txtarea.insertTextRange( txtarea.getSelection() + "[img]" + image_url + "[/img]" );
-	}
-	//self.close();
   <script>{literal}
+/**
+ * function for inserting uploaded images into
+ * a posting from the uploaded images gallery
+ */
+function insertCode() {
+  const clickedButton = event.target.closest('button');
+  if (clickedButton === null) return false;
+  const imagePath = clickedButton.querySelector('img').getAttribute('src');
+  if (opener && opener.mlfBBCodeButton) {
+    const bbcodeButton = opener.mlfBBCodeButton;
+    if (!bbcodeButton.canInsert()) return;
+    const buttonGroup = bbcodeButton.getButtonGroup();
+    const txtarea = buttonGroup.getTextArea();
+    txtarea.insertTextRange( txtarea.getSelection() + "[img]" + imagePath + "[/img]" );
+  }
+  //self.close();
 }
 window.addEventListener('DOMContentLoaded', function() {
   if (document.querySelector('div.insert-desc')) {

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -8,7 +8,6 @@
 {literal}
 <!--
 img           { border:none; }
-#header       { margin:0; padding:0; background:#f9f9f9; border-bottom: 1px solid #bacbdf; height:24px; font-size:13px; line-height:22px; }
 #nav-1        { margin:0; padding:0 0 0 5px; float:left; }
 #nav-2        { margin:0; padding:0 5px 0 0; float:right; }
 #wrapper      { margin:0; padding:20px; }
@@ -23,6 +22,14 @@ body {
   font-size: 1em;
   font-size: 1rem;
   line-height: 1.5;
+}
+#header {
+  margin: 0;
+  background: #f9f9f9;
+  border-bottom: 1px solid #bacbdf;
+  height: 24px;
+  font-size:13px;
+  line-height:22px;
 }
 .caution      { padding: 0px 0px 0px 20px; color: red; font-weight: bold; background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/caution.png); background-repeat:no-repeat; background-position: left; }
 .ok           { padding: 0px 0px 0px 20px; font-weight:bold; color:red; background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/tick.png); background-repeat:no-repeat; background-position: left; }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -115,6 +115,9 @@ ul {
   display:flex;
   flex-direction:column;
   gap:0.75em;
+  min-width: 20em;
+  max-width: 40em;
+  margin-inline: auto;
 }
 #del-upload-form,
 #imgtab li {

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -127,6 +127,11 @@ img {
 button {
   cursor: pointer;
 }
+#imgtab li button:has(> img) {
+  background: transparent;
+  border: none;
+  padding: 0;
+}
 -->
 {/literal}
   </style>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -146,6 +146,9 @@ function insertCode() {
   //self.close();
 }
 window.addEventListener('DOMContentLoaded', function() {
+  if (document.querySelector('#imgtab button')) {
+    document.querySelector('#imgtab').addEventListener('click', insertCode);
+  }
   if (document.querySelector('div.insert-desc')) {
     const descriptors = document.querySelectorAll('div.insert-desc');
     descriptors.forEach(function (descriptor) {

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -119,6 +119,11 @@ img {
   max-width: 50%;
   height: auto;
 }
+.buttonbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3em;
+}
 -->
 {/literal}
   </style>
@@ -152,14 +157,17 @@ function insertCode(image_url) {
    </ul>
   </div>
 {/if}
-<form id="uploadform" action="index.php" method="post" enctype="multipart/form-data" accept-charset="{#charset#}">
-<div>
-<input type="hidden" name="mode" value="upload_image" />
-<p><input type="file" name="probe" size="17" /></p>
-<p><input type="submit" name="" value="{#upload_image_button#}" onclick="document.getElementById('throbber-submit').style.visibility='visible'" /> <img id="throbber-submit" style="visibility:hidden;" src="{$THEMES_DIR}/{$theme}/images/throbber_submit.gif" alt="" width="16" height="16" /></p>
-</div>
-</form>
-<p class="small"><a href="index.php?mode=upload_image&amp;browse_images=1">{#browse_uploaded_images#}</a></p>
+  <form id="uploadform" action="index.php" method="post" enctype="multipart/form-data" accept-charset="{#charset#}">
+   <input type="hidden" name="mode" value="upload_image" />
+   <div>
+    <input type="file" name="probe" size="17" />
+   </div>
+   <div class="buttonbar">
+    <button value="{#upload_image_button#}" onclick="document.getElementById('throbber-submit').style.visibility='visible'">{#upload_image_button#}</button>
+    <img id="throbber-submit" style="visibility:hidden;" src="{$THEMES_DIR}/{$theme}/images/throbber_submit.gif" alt="" width="16" height="16" />
+   </div>
+  </form>
+  <p class="small"><a href="index.php?mode=upload_image&amp;browse_images=1">{#browse_uploaded_images#}</a></p>
  </div>
 {elseif $uploaded_file}
  <div id="header">

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <style type="text/css">
 {literal}
-<!--
 *,
 ::before,
 ::after {
@@ -152,7 +151,6 @@ button {
   border: none;
   padding: 0;
 }
--->
 {/literal}
   </style>
   <script>{literal}

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -140,6 +140,16 @@ function insertCode(image_url) {
 	//self.close();
 }
 /* ]]> */{/literal}</script>
+window.addEventListener('DOMContentLoaded', function() {
+  if (document.querySelector('div.insert-desc')) {
+    const descriptors = document.querySelectorAll('div.insert-desc');
+    descriptors.forEach(function (descriptor) {
+      const description = document.createElement('p');
+      description.textContent = '{/literal}{#insert_image_exp#|escape:quotes}{literal}';
+      descriptor.replaceChildren(description);
+    });
+  }
+});
  </head>
  <body>
 {if $form}

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -103,10 +103,10 @@ li > div:last-child {
 img {
   border:none;
   display: block;
-  margin-inline: auto;
 }
 #imgtab img {
   max-width: 100%;
+  margin-inline: auto;
   cursor: pointer;
 }
 #imgtab.shrinked img {

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -115,7 +115,9 @@ window.onresize = getMaxWidth;
  </head>
  <body>
 {if $form}
-<h1>{#upload_image_hl#}</h1>
+ <div id="header">
+  <h1>{#upload_image_hl#}</h1>
+ </div>
  <div id="wrapper">
 {if $errors}
   <div class="caution">
@@ -137,7 +139,9 @@ window.onresize = getMaxWidth;
 <p class="small"><a href="index.php?mode=upload_image&amp;browse_images=1">{#browse_uploaded_images#}</a></p>
  </div>
 {elseif $uploaded_file}
-<h1>{#upload_image_hl#}</h1>
+ <div id="header">
+  <h1>{#upload_image_hl#}</h1>
+ </div>
  <div id="wrapper">
   <div class="ok">
    <h2>{#upload_successful#}</h2>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -196,8 +196,8 @@ function insertCode(image_url) {
   </ul>
  </div>
 {else}
-<p>{#no_images#}</p>
  <div id="wrapper">
+  <p>{#no_images#}</p>
  </div>
 {/if}
 {elseif $delete_confirm}

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -37,22 +37,23 @@ h1 {
   font-size: 1.2em;
   font-weight: bold;
 }
+.caution,
+.ok {
+  margin-block: 0.5em;
+  padding: 0 0 0 24px;
+  background-repeat:no-repeat;
+  background-position: 2px 3px;
+}
 }
 .caution {
-  padding: 0px 0px 0px 20px;
   font-weight: bold;
   color: #cc0000;
   background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/caution.png);
-  background-repeat:no-repeat;
-  background-position: left;
 }
 .ok {
-  padding: 0px 0px 0px 20px;
   font-weight:bold;
   color:green;
   background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/tick.png);
-  background-repeat:no-repeat;
-  background-position: left;
 }
 img.delete    { max-width:300px; max-height:150px; }
 img.uploaded  { max-width:300px; max-height:110px; /*cursor:pointer;*/ }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -9,8 +9,6 @@
 <!--
 img           { border:none; }
 #wrapper      { margin:0; padding:20px; }
-h1            { font-family: verdana, arial, sans-serif; font-size: 18px; font-weight: bold; }
-p             { font-family: verdana, arial, sans-serif; font-size: 13px; line-height: 19px; }
 body {
   color: #000;
   background: #fff;
@@ -32,6 +30,12 @@ body {
   margin:0;
   padding:0;
 }
+h1 {
+  font-family: verdana, arial, sans-serif;
+  font-size: 18px;
+  font-weight: bold;
+}
+p             { font-family: verdana, arial, sans-serif; font-size: 13px; line-height: 19px; }
 .caution      { padding: 0px 0px 0px 20px; color: red; font-weight: bold; background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/caution.png); background-repeat:no-repeat; background-position: left; }
 .ok           { padding: 0px 0px 0px 20px; font-weight:bold; color:red; background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/tick.png); background-repeat:no-repeat; background-position: left; }
 img.delete    { max-width:300px; max-height:150px; }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -72,7 +72,11 @@ h1 {
 }
 img.delete    { max-width:300px; max-height:150px; }
 img.uploaded  { max-width:300px; max-height:110px; /*cursor:pointer;*/ }
-.deletelink   { font-size:11px; padding-left:13px; background:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/bg_sprite_3.png) no-repeat 0 -47px; }
+.deletelink {
+  font-size:11px;
+  padding-left:13px;
+  background:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/bg_sprite_3.png) no-repeat 0 -47px;
+}
 .small        {
   font-size: 0.86em;
 }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -39,7 +39,7 @@ body > * {
   padding:0;
 }
 h1 {
-  font-size: 1.2em;
+  font-size: 1em;
   font-weight: bold;
 }
 .caution,

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -49,14 +49,16 @@ h1 {
   background-repeat:no-repeat;
   background-position: 2px 3px;
 }
+.caution h2,
+.ok h2 {
+  font-size: 1em;
+  margin: 0 0 0.5em 0;
 }
 .caution {
-  font-weight: bold;
   color: #cc0000;
   background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/caution.png);
 }
 .ok {
-  font-weight:bold;
   color:green;
   background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/tick.png);
 }
@@ -112,12 +114,14 @@ window.onresize = getMaxWidth;
 <div id="wrapper">
 <h1>{#upload_image_hl#}</h1>
 {if $errors}
-<p class="caution">{#error_headline#}</p>
-<ul>
+  <div class="caution">
+   <h2>{#error_headline#}</h2>
+   <ul>
 {section name=mysec loop=$errors}
-<li>{assign var="error" value=$errors[mysec]}{$smarty.config.$error|replace:"[width]":$width|replace:"[height]":$height|replace:"[filesize]":$filesize|replace:"[max_width]":$max_width|replace:"[max_height]":$max_height|replace:"[max_filesize]":$max_filesize|replace:"[server_max_filesize]":$server_max_filesize}</li>
+    <li>{assign var="error" value=$errors[mysec]}{$smarty.config.$error|replace:"[width]":$width|replace:"[height]":$height|replace:"[filesize]":$filesize|replace:"[max_width]":$max_width|replace:"[max_height]":$max_height|replace:"[max_filesize]":$max_filesize|replace:"[server_max_filesize]":$server_max_filesize}</li>
 {/section}
-</ul>
+   </ul>
+  </div>
 {/if}
 <form id="uploadform" action="index.php" method="post" enctype="multipart/form-data" accept-charset="{#charset#}">
 <div>
@@ -131,7 +135,9 @@ window.onresize = getMaxWidth;
 {elseif $uploaded_file}
 <div id="wrapper">
 <h1>{#upload_image_hl#}</h1>
-<p class="ok">{#upload_successful#}</p>
+  <div class="ok">
+   <h2>{#upload_successful#}</h2>
+  </div>
 {*<script type="text/javascript">/* <![CDATA[ */document.write('<p>{#insert_image_exp#|escape:quotes}<\/p>'); /* ]]> */</script>*}
 <noscript><p>{#insert_image_exp_no_js#}</p>
 <p><code>[img]images/uploaded/{$uploaded_file}[/img]</code></p></noscript>
@@ -163,7 +169,6 @@ window.onresize = getMaxWidth;
 <div id="nav-1"><a href="index.php?mode=upload_image&amp;browse_images={$current|default:'1'}">{#back#}</a></div>
 </div>
 <div id="wrapper">
-<p class="caution">{#delete_image_confirm#}</p>
 <p><img class="delete" src="images/uploaded/{$delete}" alt="{$delete}" /></p>
 <form id="uploadform" action="index.php" method="post" accept-charset="{#charset#}">
 <div>
@@ -174,10 +179,15 @@ window.onresize = getMaxWidth;
 </div>
 </form>
 </div>
+  <div class="caution">
+   <h2>{#delete_image_confirm#}</h2>
+  </div>
 {else}
 <div id="wrapper">
-<p class="caution">{#image_upload_not_enabled#}</p>
 </div>
+  <div class="caution">
+   <h2>{#image_upload_not_enabled#}</h2>
+  </div>
 {/if}
 </body>
 </html>

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -28,8 +28,6 @@ body {
   background: #f9f9f9;
   border-bottom: 1px solid #bacbdf;
   height: 24px;
-  font-size:13px;
-  line-height:22px;
 }
 .caution      { padding: 0px 0px 0px 20px; color: red; font-weight: bold; background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/caution.png); background-repeat:no-repeat; background-position: left; }
 .ok           { padding: 0px 0px 0px 20px; font-weight:bold; color:red; background-image:url({/literal}{$THEMES_DIR}/{$settings.theme}{literal}/images/tick.png); background-repeat:no-repeat; background-position: left; }

--- a/themes/default/upload_image.tpl
+++ b/themes/default/upload_image.tpl
@@ -76,7 +76,10 @@ img.uploaded  { max-width:300px; max-height:110px; /*cursor:pointer;*/ }
 .small        {
   font-size: 0.86em;
 }
-code          { font-family:"courier new", courier; color:#000080; }
+code {
+  font-family:"courier new", courier;
+  color:#000080;
+}
 a:link        { color:#0000cc; text-decoration: none; }
 a:visited     { color:#0000cc; text-decoration: none; }
 a:hover       { color:#0000ff; text-decoration: underline; }


### PR DESCRIPTION
Beginning with solving the bug, mentioned in issue #770, I found several further issues in the template, that made a complete rework necessary. Doing this, a bunch of further small issues was solved within.

In detail, the following changes were made.

- The view of already uploaded images packaged in a list.
- The other views, displaying the just now uploaded image or the one when confirming the deletion of an image, got the same list structure, even only one image is shown.
- The images, that should be clickable, are packed in a button because buttons are interactive elements while images are not.
- The inline JavaScript code to insert an image into a posting got removed.
- The function `insertCode` to insert an image into a posting was reworked to reflect the change of the HTML-structure and to use the buttons around the images.
- The description for inserting images without active JavaScript was reworked and will now be displayed below the image itself.
- The inline JavaScript to replace the non-JavaScript-description with the description for active JavaScript was removed and replaced with new code in the head section of the document.
- The images in the view of already uploaded images got individual descriptions for inserting them into a posting (both the non-JavaScript and JavaScript way).
- The elements `div#header` and `div#wrapper` was replaced with `header` respectively `main` and applied to all possible views (with exception of the view when the upload feature is deactivated, there's no `header`).
- The HTML-structure for error, warning and success messages was unified.
- The CSS-rules was reformatted, changed and newly introduced for many elements and substructures.
- And last but not least, the adjustment of image sizes via JavaScript has been replaced with a CSS-only solution. This fixes #770.
