### PR TITLE
Take the time od a posting into acount when checking for a reserved username

### DIFF
--- a/includes/posting.inc.php
+++ b/includes/posting.inc.php
@@ -780,6 +780,11 @@ switch ($action) {
 				if ($id == 0 && $categories != false && empty($categories[$p_category]))
 					$errors[] = 'error_invalid_category';
 				
+				if ($posting_mode == 1 && !empty($field['time'])) {
+					$posting_time = format_time('YYYY-MM-dd HH:mm:ss', $field['time']);
+				} else {
+					$posting_time = format_time('YYYY-MM-dd HH:mm:ss', time());
+				}
 				if (!$isModOrAdmin) {
 					// name reserved?
 					$result = mysqli_query($connid, "SELECT user_id, user_name FROM " . $db_settings['userdata_table'] . " WHERE lower(user_name) = '" . mysqli_real_escape_string($connid, my_strtolower($name, $lang['charset'])) . "'") or raise_error('database_error', mysqli_error($connid));

--- a/includes/posting.inc.php
+++ b/includes/posting.inc.php
@@ -787,7 +787,9 @@ switch ($action) {
 				}
 				if (!$isModOrAdmin) {
 					// name reserved?
-					$result = mysqli_query($connid, "SELECT user_id, user_name FROM " . $db_settings['userdata_table'] . " WHERE lower(user_name) = '" . mysqli_real_escape_string($connid, my_strtolower($name, $lang['charset'])) . "'") or raise_error('database_error', mysqli_error($connid));
+					$result = mysqli_query($connid, "SELECT user_id, user_name FROM " . $db_settings['userdata_table'] . "
+					WHERE lower(user_name) = '" . mysqli_real_escape_string($connid, my_strtolower($name, $lang['charset'])) . "'
+					AND registered > '". mysqli_real_escape_string($connid, $posting_time) ."'") or raise_error('database_error', mysqli_error($connid));
 					if (mysqli_num_rows($result) > 0) {
 						if (empty($_SESSION[$settings['session_prefix'] . 'user_id'])) {
 							$errors[] = 'error_name_reserved';


### PR DESCRIPTION
When checking for a username collision we came across the situation, that editing a specific posting was not possible because the author of the posting registered in the project forum with the same name *after* he wrote the named posting. Editing failed because the check for a username collision found the username and did not save the edited posting.

Further details can be found in the issue #750.

A first step was done with excluding administrators and moderators from the check in #751. Those people should be able to edit a posting without any any exception. Now we want to take the second step, by adding a second condition to the query, that checks, if the posting was written *before* a user had registered with the same name as the posting autor.

For this we take the initial time of posting in case of editing a posting and the current timestamp in case of writing a new posting and compare it with the registration time of a potential colliding username. When writing a new posting, the posting time is automatically later than any registration time but a posting of ABC can be written before a user registered under the identical name and *in this case* editing a posting should be also allowed for people who are neither moderators nor administrators.

**Missing**: RegEx for checking that the content of the variable `$posting_time` has the format `YYYY-MM-DD HH:MM:SS`.