### PR TITLE
Missing information about MySQLi-errors in the upgrade script

### DIFF
--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -15,6 +15,12 @@ if(!defined('IN_INDEX')) exit;
 if(empty($_SESSION[$settings['session_prefix'].'user_type'])) exit;
 if($_SESSION[$settings['session_prefix'].'user_type']!=2) exit;
 
+// configure the error reporting of the MySQL connection
+// defaults to these values with PHP 8.1 and newer
+// but is needed for older PHP versions because it
+// defaults to MYSQLI_REPORT_OFF there 
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
 // update data:
 $update['version'] = array('2.4.19', '2.4.19.1', '2.4.20', '2.4.21', '2.4.22', '2.4.23', '2.4.24', '2.4.99.0', '2.4.99.1', '2.4.99.2', '2.4.99.3', '20220508.1', '20220509.1', '20220517.1', '20220529.1', '20220803.1', '20240308.1', '20240729.1', '20240827.1');
 $update['download_url'] = 'https://github.com/My-Little-Forum/mylittleforum/releases/latest';

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -528,8 +528,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					mysqli_commit($connid);
 				} catch (mysqli_sql_exception $exception) {
 					mysqli_rollback($connid);
-					$update['errors'][] = mysqli_errno($connid) .", ". mysqli_error($connid). ", " . $exception->getMessage();
-					//throw $exception;
+					$update['errors'][] = "Error in line ". $exception->getLine() .": ". $exception->getCode() .", ". $exception->getMessage();
 				}
 				mysqli_autocommit($connid, true);
 			}
@@ -975,8 +974,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.99.0')
 				mysqli_commit($connid);
 			} catch (mysqli_sql_exception $exception) {
 				mysqli_rollback($connid);
-				$update['errors'][] = mysqli_errno($connid) .", ". mysqli_error($connid). ", " . $exception->getMessage();
-				//throw $exception;
+				$update['errors'][] = "Error in line ". $exception->getLine() .": ". $exception->getCode() .", ". $exception->getMessage();
 			}
 		}
 		mysqli_autocommit($connid, true);
@@ -1370,8 +1368,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.99.1')
 				mysqli_commit($connid);
 			} catch (mysqli_sql_exception $exception) {
 				mysqli_rollback($connid);
-				$update['errors'][] = mysqli_errno($connid) .", ". mysqli_error($connid). ", " . $exception->getMessage();
-				//throw $exception;
+				$update['errors'][] = "Error in line ". $exception->getLine() .": ". $exception->getCode() .", ". $exception->getMessage();
 			}
 		}
 		mysqli_autocommit($connid, true);
@@ -1786,8 +1783,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.99.2',
 				mysqli_commit($connid);
 			} catch (mysqli_sql_exception $exception) {
 				mysqli_rollback($connid);
-				$update['errors'][] = mysqli_errno($connid) .", ". mysqli_error($connid). ", " . $exception->getMessage();
-				//throw $exception;
+				$update['errors'][] = "Error in line ". $exception->getLine() .": ". $exception->getCode() .", ". $exception->getMessage();
 			}
 		}
 		mysqli_autocommit($connid, true);
@@ -2166,8 +2162,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('20220508.1
 				mysqli_commit($connid);
 			} catch (mysqli_sql_exception $exception) {
 				mysqli_rollback($connid);
-				$update['errors'][] = mysqli_errno($connid) .", ". mysqli_error($connid). ", " . $exception->getMessage();
-				//throw $exception;
+				$update['errors'][] = "Error in line ". $exception->getLine() .": ". $exception->getCode() .", ". $exception->getMessage();
 			}
 		}
 		mysqli_autocommit($connid, true);
@@ -2430,8 +2425,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('20220517.1
 				mysqli_commit($connid);
 			} catch (mysqli_sql_exception $exception) {
 				mysqli_rollback($connid);
-				$update['errors'][] = mysqli_errno($connid) .", ". mysqli_error($connid). ", " . $exception->getMessage();
-				//throw $exception;
+				$update['errors'][] = "Error in line ". $exception->getLine() .": ". $exception->getCode() .", ". $exception->getMessage();
 			}
 		}
 		mysqli_autocommit($connid, true);
@@ -2694,8 +2688,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('20220803.1
 				mysqli_commit($connid);
 			} catch (mysqli_sql_exception $exception) {
 				mysqli_rollback($connid);
-				$update['errors'][] = mysqli_errno($connid) .", ". mysqli_error($connid). ", " . $exception->getMessage();
-				//throw $exception;
+				$update['errors'][] = "Error in line ". $exception->getLine() .": ". $exception->getCode() .", ". $exception->getMessage();
 			}
 		}
 		mysqli_autocommit($connid, true);
@@ -2823,8 +2816,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('20240308.1
 				mysqli_commit($connid);
 			} catch (mysqli_sql_exception $exception) {
 				mysqli_rollback($connid);
-				$update['errors'][] = mysqli_errno($connid) .", ". mysqli_error($connid). ", " . $exception->getMessage();
-				//throw $exception;
+				$update['errors'][] = "Error in line ". $exception->getLine() .": ". $exception->getCode() .", ". $exception->getMessage();
 			}
 		}
 		mysqli_autocommit($connid, true);
@@ -2918,8 +2910,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('20240729.1
 				mysqli_commit($connid);
 			} catch (mysqli_sql_exception $exception) {
 				mysqli_rollback($connid);
-				$update['errors'][] = mysqli_errno($connid) .", ". mysqli_error($connid). ", " . $exception->getMessage();
-				//throw $exception;
+				$update['errors'][] = "Error in line ". $exception->getLine() .": ". $exception->getCode() .", ". $exception->getMessage();
 			}
 		}
 		mysqli_autocommit($connid, true);
@@ -3013,8 +3004,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('20240827.1
 				mysqli_commit($connid);
 			} catch (mysqli_sql_exception $exception) {
 				mysqli_rollback($connid);
-				$update['errors'][] = mysqli_errno($connid) .", ". mysqli_error($connid). ", " . $exception->getMessage();
-				//throw $exception;
+				$update['errors'][] = "Error in line ". $exception->getLine() .": ". $exception->getCode() .", ". $exception->getMessage();
 			}
 		}
 		mysqli_autocommit($connid, true);


### PR DESCRIPTION
Until now we utilised the classic PHP functions `mysqli_errno` and `mysqli_error` to display errors in the queries of the upgrade script. But because we use transactions in a try-catch-block to process all queries of an upgrade step, these functions does not contain any information in the catch block.

With using the information from the exception object to display MySQL error information (`$e->getLine()`, `$e->getCode()` and the always present `$e->getMessage()`), we now get the number of the first line of the affected query, the error code from the MySQL-server and the servers error message.