### PR TITLE
Rework of the sidebar toggle

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -511,23 +511,16 @@ function DragAndDropTable(table,mode,queryKey) {
 	 */
 	function Sidebar(templatePath) {
 		templatePath = templatePath || "";
-		var icon    = document.getElementById("sidebartoggle");
-		if (!main || !icon)
 		const main   = document.getElementById("sidebar") || document.getElementById("bottombar") || false;
 		const self   = this;
+		if (!main)
 			return;
 		this.setVisible = function(visible) {
 			if (visible) {
 				main.classList.remove("js-display-fold");
-				icon.src = templatePath + settings["hide_sidebar_image"];
-				icon.classList.remove("show-sidebar");
-				icon.classList.add("hide-sidebar");
 			}
 			else {
 				main.classList.add("js-display-fold");
-				icon.src = templatePath + settings["show_sidebar_image"];
-				icon.classList.remove("hide-sidebar");
-				icon.classList.add("show-sidebar");
 			}
 		};
 		this.isVisible = function() {

--- a/js/main.js
+++ b/js/main.js
@@ -511,10 +511,10 @@ function DragAndDropTable(table,mode,queryKey) {
 	 */
 	function Sidebar(templatePath) {
 		templatePath = templatePath || "";
-		var main    = document.getElementById("sidebar") || document.getElementById("bottombar") || false;
 		var icon    = document.getElementById("sidebartoggle");
-		var self    = this;
 		if (!main || !icon)
+		const main   = document.getElementById("sidebar") || document.getElementById("bottombar") || false;
+		const self   = this;
 			return;
 		this.setVisible = function(visible) {
 			if (visible) {

--- a/js/main.js
+++ b/js/main.js
@@ -526,18 +526,14 @@ function DragAndDropTable(table,mode,queryKey) {
 		this.isVisible = function() {
 			return !main.classList.contains("js-display-fold");
 		};
-		var links = main.getElementsByTagName("a");
-		for (var i=0; i<links.length; i++) {
-			if (links[i].href.search(/toggle_sidebar/) != -1) {
-				links[i].onclick = function(e) {
-					self.setVisible(!self.isVisible());
-					new Request("index.php", "POST", new Query("toggle_sidebar", true));
-					return false;
-				}
-			}
+		const link = main.querySelector(".sidebar a");
+		link.onclick = function(e) {
+			self.setVisible(!self.isVisible());
+			new Request("index.php", "POST", new Query("toggle_sidebar", true));
+			return false;
 		}
 	};
-		
+	
 	/**
 	 * Thread object, which is created by an UL element or the numerical ID of the UL element,
 	 * which is used to collapse the tree

--- a/themes/default/images/triangle-bottom.svg
+++ b/themes/default/images/triangle-bottom.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" standalone="yes"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+ <style type="text/css">
+  <![CDATA[
+  svg { background: transparent; }
+  path { fill: #a8afbb; stroke-width: 10; stroke: #a8afbb; stroke-linejoin: round; }
+  ]]>
+ </style>
+ <path d="M 64,118 8,42 120,42 z" />
+</svg>
+

--- a/themes/default/images/triangle-left.svg
+++ b/themes/default/images/triangle-left.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" standalone="yes"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+ <style type="text/css">
+  <![CDATA[
+  svg { background: transparent; }
+  path { fill: #a8afbb; stroke-width: 10; stroke: #a8afbb; stroke-linejoin: round; }
+  ]]>
+ </style>
+ <path d="M10,64 86,120 86,8 z" />
+</svg>
+

--- a/themes/default/images/triangle-right.svg
+++ b/themes/default/images/triangle-right.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" standalone="yes"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+ <style type="text/css">
+  <![CDATA[
+  svg { background: transparent; }
+  path { fill: #a8afbb; stroke-width: 10; stroke: #a8afbb; stroke-linejoin: round; }
+  ]]>
+ </style>
+ <path d="M118,64 42,120 42,8 z" />
+</svg>
+

--- a/themes/default/images/triangle-top.svg
+++ b/themes/default/images/triangle-top.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" standalone="yes"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+ <style type="text/css">
+  <![CDATA[
+  svg { background: transparent; }
+  path { fill: #a8afbb; stroke-width: 10; stroke: #a8afbb; stroke-linejoin: round; }
+  ]]>
+ </style>
+ <path d="M 64,10 120,86 8,86 z" />
+</svg>
+

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -100,8 +100,8 @@ html[dir="rtl"] #footermenu a.go-to-top-link{background:url(images/arrow_up.png)
 #sidebar{grid-area:sidebar;position:relative;margin:0;padding:0}
 #sidebar div{position:relative;z-index:2}
 #sidebarcontent div:not(:last-child){margin: 0 0 .75em 0}
-h2.sidebar{font-size:.82em;line-height:1.7em;font-weight:700;margin-block:0 .75em;margin-inline:0;padding-block:0;padding-inline:.375em 17px;background:#d2ddea;background:linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 100%);border:1px solid #bacbdf;z-index:1}
 h2.sidebar a{color:#000;text-decoration:none;z-index:2}
+h2.sidebar{font-size:.82em;line-height:1.7;font-weight:bold;margin-block:0 .75em;margin-inline:0;padding:0;background:#d2ddea;background:linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 100%);border:1px solid #bacbdf;z-index:1}
 .js-display-fold h2.sidebar {margin-block:0}
 #sidebarcontent div h3{font-size:.82em;line-height:1.7;font-weight:400;margin:0;padding:0 .375em;background:#d2ddea;background:linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 100%)}
 #latest-postings{background:#f9f9f9;border:1px solid #bacbdf;padding:0}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -508,8 +508,8 @@ form .hp{display:none}
 	#admin-main-menu{grid-template-areas:"infoboxes mainmenu";grid-template-columns:18em auto;grid-template-rows:auto}
 	#main-grid.threaded {grid-template-areas:"threadlist sidebar";grid-template-columns:auto 18em;grid-template-rows:auto}
 	#main-grid.threaded:has(div.js-display-fold){grid-template-columns:auto 8.5em}
-	h2.sidebar a{padding-inline:1.175em .375em;background:url("images/triangle-right.svg") 0.175em center/0.9em 0.9em no-repeat}
-	.js-display-fold h2.sidebar a{background:url("images/triangle-left.svg") 0.175em center/0.9em 0.9em no-repeat}
+	h2.sidebar a{padding-inline:1.25em .375em;background:url("images/triangle-right.svg") 0.175em center/0.9em 0.9em no-repeat}
+	.js-display-fold h2.sidebar a{background:url("images/triangle-left.svg") 0.325em center/0.9em 0.9em no-repeat}
 	html[dir="rtl"] h2.sidebar a{background:url("images/triangle-left.svg") calc(100% - 0.175em) center/0.9em 0.9em no-repeat}
 	html[dir="rtl"] .js-display-fold h2.sidebar a{background:url("images/triangle-right.svg") calc(100% - 0.175em) center/0.9em 0.9em no-repeat}
 }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -103,7 +103,6 @@ html[dir="rtl"] #footermenu a.go-to-top-link{background:url(images/arrow_up.png)
 h2.sidebar{font-size:.82em;line-height:1.7em;font-weight:700;margin-block:0 .75em;margin-inline:0;padding-block:0;padding-inline:.375em 17px;background:#d2ddea;background:linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 100%);border:1px solid #bacbdf;z-index:1}
 h2.sidebar a{color:#000;text-decoration:none;z-index:2}
 .js-display-fold h2.sidebar {margin-block:0}
-#sidebartoggle{position:absolute;top:7px;inset-inline-end:4px;margin:0;padding:0;z-index:3}
 #sidebarcontent div h3{font-size:.82em;line-height:1.7;font-weight:400;margin:0;padding:0 .375em;background:#d2ddea;background:linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 100%)}
 #latest-postings{background:#f9f9f9;border:1px solid #bacbdf;padding:0}
 #latest-postings a.hide-sidebar{position:absolute;top:2px;right:4px;margin:0;padding:0;line-height:11px}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -100,8 +100,10 @@ html[dir="rtl"] #footermenu a.go-to-top-link{background:url(images/arrow_up.png)
 #sidebar{grid-area:sidebar;position:relative;margin:0;padding:0}
 #sidebar div{position:relative;z-index:2}
 #sidebarcontent div:not(:last-child){margin: 0 0 .75em 0}
-h2.sidebar a{color:#000;text-decoration:none;z-index:2}
 h2.sidebar{font-size:.82em;line-height:1.7;font-weight:bold;margin-block:0 .75em;margin-inline:0;padding:0;background:#d2ddea;background:linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 100%);border:1px solid #bacbdf;z-index:1}
+h2.sidebar a{display:block;color:#000;padding-inline:1.625em .375em;background:url("images/triangle-top.svg") 0.375em calc(50% + .075em)/0.9em 0.9em no-repeat;text-decoration:none}
+.js-display-fold h2.sidebar a{background:url("images/triangle-bottom.svg") 0.375em calc(50% - .075em)/0.9em 0.9em no-repeat}
+h2.sidebar a:focus,h2.sidebar a:hover,h2.sidebar a:active{text-decoration:underline}
 .js-display-fold h2.sidebar {margin-block:0}
 #sidebarcontent div h3{font-size:.82em;line-height:1.7;font-weight:400;margin:0;padding:0 .375em;background:#d2ddea;background:linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 100%)}
 #latest-postings{background:#f9f9f9;border:1px solid #bacbdf;padding:0}
@@ -506,6 +508,10 @@ form .hp{display:none}
 	#admin-main-menu{grid-template-areas:"infoboxes mainmenu";grid-template-columns:18em auto;grid-template-rows:auto}
 	#main-grid.threaded {grid-template-areas:"threadlist sidebar";grid-template-columns:auto 18em;grid-template-rows:auto}
 	#main-grid.threaded:has(div.js-display-fold){grid-template-columns:auto 8.5em}
+	h2.sidebar a{padding-inline:1.175em .375em;background:url("images/triangle-right.svg") 0.175em center/0.9em 0.9em no-repeat}
+	.js-display-fold h2.sidebar a{background:url("images/triangle-left.svg") 0.175em center/0.9em 0.9em no-repeat}
+	html[dir="rtl"] h2.sidebar a{background:url("images/triangle-left.svg") calc(100% - 0.175em) center/0.9em 0.9em no-repeat}
+	html[dir="rtl"] .js-display-fold h2.sidebar a{background:url("images/triangle-right.svg") calc(100% - 0.175em) center/0.9em 0.9em no-repeat}
 }
 @media screen and (min-width:48em) {
 	#logo h1{font-size:1.6em}

--- a/themes/default/subtemplates/index.inc.tpl
+++ b/themes/default/subtemplates/index.inc.tpl
@@ -1,7 +1,6 @@
 {if $tag_cloud || $latest_postings || $admin || $mod}
 <div id="main-grid" class="threaded">
 <div id="sidebar"{if $usersettings.sidebar==0} class="js-display-fold"{/if}>
-<a href="index.php?toggle_sidebar=true"><img id="sidebartoggle" class="{if $usersettings.sidebar==0}show-sidebar{else}hide-sidebar{/if}" src="{$THEMES_DIR}/{$theme}/images/plain.png" title="{#toggle_sidebar#}" alt="[+/-]" width="9" height="9" /></a>
 <h2 class="sidebar"><a href="index.php?toggle_sidebar=true" title="{#toggle_sidebar#}">{#sidebar#}</a></h2>
 <div id="sidebarcontent">
 {if $latest_postings}


### PR DESCRIPTION
One of the changes in the last rework of the sidebar was that the toggle switch is permanently displayed. This increased the link area enormously, as it was previously only nine by nine pixels when the sidebar was expanded.

The current change extends the link area to the entire displayed box and replaces the small icon with more visible background images. In narrow viewports, in which the sidebar is displayed above the thread list, icons are used that show the unfolding and folding direction upwards and downwards. In wide viewports, the icons point to the side in the direction of the action that can be triggered. This is implemented including support of left to right and right to left writing directions.

Furthermore the link text gets underlined when it is focused, hovered or active.

As part of these changes, the JavaScript sidebar function has also been revised and simplified by removing the old icon and directly selecting the now single toggle link. @loesler Please add the minified JS code (main.min.js) to the pull request after a review of my changes or open a separate pull request for the minified code.

Partially translated with DeepL.com (free version)