### PR TITLE
Fixes for the errors in the preview section of the posting template, reported in #778

### DIFF
--- a/includes/posting.inc.php
+++ b/includes/posting.inc.php
@@ -1210,7 +1210,9 @@ switch ($action) {
 				// current time:
 				list($preview_time) = mysqli_fetch_row(mysqli_query($connid, "SELECT UNIX_TIMESTAMP(NOW() + INTERVAL " . $time_difference . " MINUTE)"));
 				$smarty->assign('preview_timestamp', $preview_time);
-				$preview_formated_time = format_time($lang['time_format_full'], $preview_time);
+				$preview_ISO_time = format_time('YYYY-MM-dd HH:mm:ss', $posting_time);
+				$smarty->assign('preview_ISO_time', $preview_ISO_time);
+				$preview_formated_time = format_time($lang['time_format_full'], $posting_time);
 				$smarty->assign('preview_formated_time', $preview_formated_time);
 				$smarty->assign('uniqid', htmlspecialchars($uniqid));
 				$smarty->assign('posting_mode', intval($posting_mode));

--- a/themes/default/subtemplates/posting.inc.tpl
+++ b/themes/default/subtemplates/posting.inc.tpl
@@ -1,5 +1,5 @@
 {config_load file=$language_file section="posting"}
-{config_load file=$language_file section="thread_entry"}
+{config_load file=$language_file section="user"}
 {if $captcha}{config_load file=$language_file section="captcha"}{/if}
 {if $no_authorisation}
 <p class="notice caution">{$smarty.config.$no_authorisation|replace:"[minutes]":$settings.edit_period}</p>
@@ -25,11 +25,11 @@
 
 {if $preview}
 {if $preview_hp && !$email}
-{assign var=email_hp value=" <a href=\"$preview_hp\"><img src=\"$THEMES_DIR/$theme/images/homepage.png\" alt=\"$homepage_alt\" width=\"13\" height=\"13\" /></a>"}
+{assign var=email_hp value=" <a href=\"$preview_hp\"><img src=\"$THEMES_DIR/$theme/images/homepage.png\" alt=\"{#homepage#}\" width=\"13\" height=\"13\" /></a>"}
 {elseif !$preview_hp && $email}
-{assign var=email_hp value=" <a href=\"index.php?mode=contact&amp;id=$id\"><img src=\"$THEMES_DIR/$theme/images/email.png\" alt=\"$email_alt\" width=\"13\" height=\"10\" /></a>"}
+{assign var=email_hp value=" <a href=\"index.php?mode=contact&amp;id=$id\"><img src=\"$THEMES_DIR/$theme/images/email.png\" alt=\"{#email#}\" width=\"13\" height=\"10\" /></a>"}
 {elseif $preview_hp && $email}
-{assign var=email_hp value=" <a href=\"$preview_hp\"><img src=\"$THEMES_DIR/$theme/images/homepage.png\" alt=\"$homepage_alt\" width=\"13\" height=\"13\" /></a> <a href=\"index.php?mode=contact&amp;id=$id\"><img src=\"$THEMES_DIR/$theme/images/email.png\" alt=\"$email_alt\" width=\"13\" height=\"10\" /></a>"}
+{assign var=email_hp value=" <a href=\"$preview_hp\"><img src=\"$THEMES_DIR/$theme/images/homepage.png\" alt=\"{#homepage#}\" width=\"13\" height=\"13\" /></a> <a href=\"index.php?mode=contact&amp;id=$id\"><img src=\"$THEMES_DIR/$theme/images/email.png\" alt=\"{#email#}\" width=\"13\" height=\"10\" /></a>"}
 {else}
 {assign var=email_hp value=""}
 {/if}

--- a/themes/default/subtemplates/posting.inc.tpl
+++ b/themes/default/subtemplates/posting.inc.tpl
@@ -38,7 +38,7 @@
 <div class="posting">
 <div class="header">
 <h1 class="postingheadline">{$preview_subject}{if $category_name} <span class="category">({$category_name})</span>{/if}</h1>
-<p class="author">{if $preview_location}{#posted_by_location#|replace:"[name]":$preview_name|replace:"[email_hp]":$email_hp|replace:"[location]":$preview_location|replace:"[time]":$preview_formated_time}{else}{#posted_by#|replace:"[name]":$preview_name|replace:"[email_hp]":$email_hp|replace:"[time]":$preview_formated_time}{/if}</p>
+<p class="author">{if $preview_location}{#posted_by_location#|replace:"[name]":$preview_name|replace:"[email_hp]":$email_hp|replace:"[location]":$preview_location}{else}{#posted_by#|replace:"[name]":$preview_name|replace:"[email_hp]":$email_hp}{/if}<time datetime="{$preview_ISO_time}">{$preview_formated_time}</time></p>
 </div>
 <div class="wrapper">
 <div class="body">{if $preview_text}{$preview_text}{else}<p>{#no_text#}</p>{/if}</div>

--- a/themes/default/subtemplates/posting.inc.tpl
+++ b/themes/default/subtemplates/posting.inc.tpl
@@ -40,7 +40,7 @@
 <h1 class="postingheadline">{$preview_subject}{if $category_name} <span class="category">({$category_name})</span>{/if}</h1>
 <p class="author">{if $preview_location}{#posted_by_location#|replace:"[name]":$preview_name|replace:"[email_hp]":$email_hp|replace:"[location]":$preview_location|replace:"[time]":$preview_formated_time}{else}{#posted_by#|replace:"[name]":$preview_name|replace:"[email_hp]":$email_hp|replace:"[time]":$preview_formated_time}{/if}</p>
 </div>
-<div class=""wrapper">
+<div class="wrapper">
 <div class="body">{if $preview_text}{$preview_text}{else}<p>{#no_text#}</p>{/if}</div>
 {if $preview_signature && $show_signature==1}
 <div class="signature"><p>---<br />

--- a/themes/default/subtemplates/posting.inc.tpl
+++ b/themes/default/subtemplates/posting.inc.tpl
@@ -113,9 +113,10 @@
   <div>
    <label for="p_category" class="input">{#category_marking#}</label>
    <select id="p_category" size="1" name="p_category" {if $posting_mode==0 && $id>0 || $posting_mode==1 && $pid>0} disabled="disabled"{/if}>
-		{foreach key=key item=val from=$categories}
-			{if $key!=0}    <option value="{$key}"{if $key==$p_category} selected="selected"{/if}>{$val}</option>{/if}
-		{/foreach}
+{foreach key=key item=val from=$categories}
+{if $key!=0}    <option value="{$key}"{if $key==$p_category} selected="selected"{/if}>{$val}</option>
+{/if}
+{/foreach}
    </select>
   </div>
 {if $posting_mode==0 && $id>0 || $posting_mode==1 && $pid>0}


### PR DESCRIPTION
- Repaired the HTML-structure of `div.wrapper`.
- Added the `time` element to the author data of the preview.
- Repaired the alternative text attributes of the icons for the link to the homepage and to the e-mail-contact-form.

Especially for the last point it is relevant to mention, that the language section `thread_entry`, which was loaded previously in line 2 of the template file, does not exist in any of the language files. I now load the existing section `user`, which provides appropriate alternative text snippets in the keys `email` and `homepage`.

These text snippets are IMHO in itself much more understandable than the text icons `⌂` and `@` which are in use in other places for the same purpose where they are supplemented by the snippets, which are used here as alternative texts, as title attributes.

For further details see #778. Fixes #778.