### PR TITLE
Restructuring the upload management

### DIFF
--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -970,8 +970,8 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 				if (!empty($listed) && !in_array($file, $listed)) {
 					$unlisted[] = $file;
 				}
+				$i++;
 			}
-			$i++;
 		}
 		closedir($handle);
 		unset($i, $listed);

--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -965,6 +965,7 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 		$handle = opendir($uploaded_images_path);
 		while ($file = readdir($handle)) {
 			if (preg_match('/\.(gif|png|jpe?g|svg|webp)$/i', $file)) {
+				$images[$i]['number'] = $i;
 				$images[$i]['pathname'] = $file;
 				if (!empty($listed) && !in_array($file, $listed)) {
 					$unlisted[] = $file;
@@ -986,7 +987,12 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 		}
 		
 		if ($images) {
-			rsort($images);
+			$sort_array = [];
+			foreach ($images as $image) {
+				$sort_array[] = $image['pathname'];
+			}
+			array_multisort($sort_array, SORT_DESC, $images);
+			unset($sort_array);
 			$page_browse['total_items'] = count($images);
 			$page_browse['items_per_page'] = $settings['uploads_per_page'];
 			$total_pages = ceil($page_browse['total_items'] / $page_browse['items_per_page']);
@@ -1007,8 +1013,8 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 	}
 
 	if (isset($_POST['delete_selected_uploads']) && isset($_POST['csrf_token']) && $_POST['csrf_token'] === $_SESSION['csrf_token']) {
-		if (isset($_POST['uploads_remove'])) {
-			$selected = $_POST['uploads_remove'];
+		if (isset($_POST['manage_uploads'])) {
+			$selected = $_POST['manage_uploads'];
 			$selected_uploads_count = count($selected);
 			for ($x=0; $x<$selected_uploads_count; $x++) {
 				$selected_uploads[$x]['name'] = htmlspecialchars($selected[$x]);

--- a/lang/arabic.lang
+++ b/lang/arabic.lang
@@ -974,6 +974,7 @@ no_users_in_selection =           'لا يوجد مستخدمون في التح�
 # upload management
 upload_administration =           'إدارة الرفع والتحميل'
 mark_upload_for_removal =         'علامة للإزالة'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                'لم يتم العثور على أي ملفات مرفوعة.'
 delete_upload_confirmation =      'هل أنت متأكد أنك تريد حذف هذا التحميل؟'
 delete_uploads_confirmation =     'هل أنت متأكد أنك تريد حذف التحميلات التالية؟'

--- a/lang/chinese.lang
+++ b/lang/chinese.lang
@@ -977,6 +977,7 @@ no_users_in_selection =           '尚未选择用户'
 # upload management
 upload_administration =           '<!-- TODO -->Upload management'
 mark_upload_for_removal =         '<!-- TODO -->mark for removal'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                '<!-- TODO -->Found no uploaded files.'
 delete_upload_confirmation =      '<!-- TODO -->Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     '<!-- TODO -->Are you sure you want to delete the following uploads?'

--- a/lang/chinese.lang
+++ b/lang/chinese.lang
@@ -980,6 +980,8 @@ mark_upload_for_removal =         '<!-- TODO -->mark for removal'
 no_uploads_found =                '<!-- TODO -->Found no uploaded files.'
 delete_upload_confirmation =      '<!-- TODO -->Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     '<!-- TODO -->Are you sure you want to delete the following uploads?'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'CAPTCHA'

--- a/lang/chinese_traditional.lang
+++ b/lang/chinese_traditional.lang
@@ -977,6 +977,7 @@ no_users_in_selection =           '尚未選擇用戶'
 # upload management
 upload_administration =           '<!-- TODO -->Upload management'
 mark_upload_for_removal =         '<!-- TODO -->mark for removal'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                '<!-- TODO -->Found no uploaded files.'
 delete_upload_confirmation =      '<!-- TODO -->Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     '<!-- TODO -->Are you sure you want to delete the following uploads?'

--- a/lang/chinese_traditional.lang
+++ b/lang/chinese_traditional.lang
@@ -980,6 +980,8 @@ mark_upload_for_removal =         '<!-- TODO -->mark for removal'
 no_uploads_found =                '<!-- TODO -->Found no uploaded files.'
 delete_upload_confirmation =      '<!-- TODO -->Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     '<!-- TODO -->Are you sure you want to delete the following uploads?'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'CAPTCHA'

--- a/lang/croatian.lang
+++ b/lang/croatian.lang
@@ -980,6 +980,8 @@ mark_upload_for_removal =         '<!-- TODO -->mark for removal'
 no_uploads_found =                '<!-- TODO -->Found no uploaded files.'
 delete_upload_confirmation =      '<!-- TODO -->Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     '<!-- TODO -->Are you sure you want to delete the following uploads?'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'CAPTCHA'

--- a/lang/croatian.lang
+++ b/lang/croatian.lang
@@ -977,6 +977,7 @@ no_users_in_selection =           'Nema korisnika koji zadovoljavaju postavljene
 # upload management
 upload_administration =           '<!-- TODO -->Upload management'
 mark_upload_for_removal =         '<!-- TODO -->mark for removal'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                '<!-- TODO -->Found no uploaded files.'
 delete_upload_confirmation =      '<!-- TODO -->Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     '<!-- TODO -->Are you sure you want to delete the following uploads?'

--- a/lang/danish.lang
+++ b/lang/danish.lang
@@ -980,6 +980,8 @@ mark_upload_for_removal =         'Markér til sletning'
 no_uploads_found =                'Ingen uploadede filer fundet.'
 delete_upload_confirmation =      'Er du sikker på, du vil slette denne upload?'
 delete_uploads_confirmation =     'Er du sikker på, du vil slette disse upload?'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'CAPTCHA'

--- a/lang/danish.lang
+++ b/lang/danish.lang
@@ -977,6 +977,7 @@ no_users_in_selection =     'Ingen brugere fundet'
 # upload management
 upload_administration =           'Uploadstyring'
 mark_upload_for_removal =         'Markér til sletning'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                'Ingen uploadede filer fundet.'
 delete_upload_confirmation =      'Er du sikker på, du vil slette denne upload?'
 delete_uploads_confirmation =     'Er du sikker på, du vil slette disse upload?'

--- a/lang/english.lang
+++ b/lang/english.lang
@@ -977,6 +977,8 @@ mark_upload_for_removal =         'mark for removal'
 no_uploads_found =                'Found no uploaded files.'
 delete_upload_confirmation =      'Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     'Are you sure you want to delete the following uploads?'
+check_for_unrecorded_uploads =    'record uploads'
+check_for_unrecorded_uploads_desc = 'Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'CAPTCHA'

--- a/lang/english.lang
+++ b/lang/english.lang
@@ -974,6 +974,7 @@ no_users_in_selection =           'No users in selection'
 # upload management
 upload_administration =           'Upload management'
 mark_upload_for_removal =         'mark for removal'
+mark_upload_for_managing =        'mark for managing'
 no_uploads_found =                'Found no uploaded files.'
 delete_upload_confirmation =      'Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     'Are you sure you want to delete the following uploads?'

--- a/lang/french.lang
+++ b/lang/french.lang
@@ -984,6 +984,8 @@ mark_upload_for_removal =         'À supprimer'
 no_uploads_found =                'Aucun téléchargement trouvé'
 delete_upload_confirmation =      'Êtes-vous sûr de vouloir supprimer ce téléchargement ?'
 delete_uploads_confirmation =     'Êtes-vous sûr de vouloir supprimer ces téléchargements ?'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'PROTECTION'

--- a/lang/french.lang
+++ b/lang/french.lang
@@ -981,6 +981,7 @@ no_users_in_selection =           'Aucun utilisateur dans la sélection'
 # upload management
 upload_administration =           'Gérer les téléchargements'
 mark_upload_for_removal =         'À supprimer'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                'Aucun téléchargement trouvé'
 delete_upload_confirmation =      'Êtes-vous sûr de vouloir supprimer ce téléchargement ?'
 delete_uploads_confirmation =     'Êtes-vous sûr de vouloir supprimer ces téléchargements ?'

--- a/lang/german.lang
+++ b/lang/german.lang
@@ -981,6 +981,8 @@ mark_upload_for_removal =         'zum löschen vormerken'
 no_uploads_found =                'Es wurden keine hochgeladenen Dateien gefunden.'
 delete_upload_confirmation =      'Sicher, dass dieser Upload gelöscht werden soll?'
 delete_uploads_confirmation =     'Sicher, dass diese Uploads gelöscht werden sollen?'
+check_for_unrecorded_uploads =    'erfasse Uploads'
+check_for_unrecorded_uploads_desc = 'Prüfe, ob Uploads vorhanden sind, die noch nicht in der Liste der Uploads erfasst sind. Falls welche gefunden werden, werden sie in der Liste eingetragen.'
 
 # Spamschutz:
 captcha =                         'CAPTCHA'

--- a/lang/german.lang
+++ b/lang/german.lang
@@ -978,6 +978,7 @@ no_users_in_selection =           'keine Benutzer in der Auswahl'
 # Uploadverwaltung
 upload_administration =           'Verwaltung der Uploads'
 mark_upload_for_removal =         'zum löschen vormerken'
+mark_upload_for_managing =        'für Verwaltung markieren'
 no_uploads_found =                'Es wurden keine hochgeladenen Dateien gefunden.'
 delete_upload_confirmation =      'Sicher, dass dieser Upload gelöscht werden soll?'
 delete_uploads_confirmation =     'Sicher, dass diese Uploads gelöscht werden sollen?'

--- a/lang/italian.lang
+++ b/lang/italian.lang
@@ -978,6 +978,7 @@ no_users_in_selection =           'Nessun utente selezionato'
 # upload management
 upload_administration =           '<!-- TODO -->Upload management'
 mark_upload_for_removal =         '<!-- TODO -->mark for removal'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                '<!-- TODO -->Found no uploaded files.'
 delete_upload_confirmation =      '<!-- TODO -->Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     '<!-- TODO -->Are you sure you want to delete the following uploads?'

--- a/lang/italian.lang
+++ b/lang/italian.lang
@@ -981,6 +981,8 @@ mark_upload_for_removal =         '<!-- TODO -->mark for removal'
 no_uploads_found =                '<!-- TODO -->Found no uploaded files.'
 delete_upload_confirmation =      '<!-- TODO -->Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     '<!-- TODO -->Are you sure you want to delete the following uploads?'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'CAPTCHA'

--- a/lang/norwegian.lang
+++ b/lang/norwegian.lang
@@ -978,6 +978,7 @@ no_users_in_selection =           'Ingen brukere i utvalget'
 # upload management
 upload_administration =           'Administrer opplastninger'
 mark_upload_for_removal =         'marker for fjerning'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                'Fant ingen opplastede filer.'
 delete_upload_confirmation =      'Er du sikker på at du vil slette denne opplastingen?'
 delete_uploads_confirmation =     'Er du sikker på at du vil slette følgende opplastinger?'

--- a/lang/norwegian.lang
+++ b/lang/norwegian.lang
@@ -981,6 +981,8 @@ mark_upload_for_removal =         'marker for fjerning'
 no_uploads_found =                'Fant ingen opplastede filer.'
 delete_upload_confirmation =      'Er du sikker på at du vil slette denne opplastingen?'
 delete_uploads_confirmation =     'Er du sikker på at du vil slette følgende opplastinger?'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'CAPTCHA'

--- a/lang/russian.lang
+++ b/lang/russian.lang
@@ -993,6 +993,8 @@ mark_upload_for_removal =         'отметить для удаления'
 no_uploads_found =                'Загруженных файлов не найдено.'
 delete_upload_confirmation =      'Вы уверены в том, что хотите удалить эту загрузку?'
 delete_uploads_confirmation =     'Вы уверены в том, что хотите удалить следующие загрузки?'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # защита от спама:
 captcha =                         'КАПЧА'

--- a/lang/russian.lang
+++ b/lang/russian.lang
@@ -990,6 +990,7 @@ no_users_in_selection =           'Пользователи не выбраны'
 # upload management
 upload_administration =           'Управление загрузкой'
 mark_upload_for_removal =         'отметить для удаления'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                'Загруженных файлов не найдено.'
 delete_upload_confirmation =      'Вы уверены в том, что хотите удалить эту загрузку?'
 delete_uploads_confirmation =     'Вы уверены в том, что хотите удалить следующие загрузки?'

--- a/lang/spanish.lang
+++ b/lang/spanish.lang
@@ -982,6 +982,8 @@ mark_upload_for_removal =         'marcar para eliminación'
 no_uploads_found =                'No se han encontrado archivos subidos.'
 delete_upload_confirmation =      '¿Estas seguro que quieres eliminar esta subida?'
 delete_uploads_confirmation =     '¿Estás seguro que quieres eliminar las siguientes subidas?'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'CAPTCHA'

--- a/lang/spanish.lang
+++ b/lang/spanish.lang
@@ -979,6 +979,7 @@ no_users_in_selection =           'No hay usuarios en la selección'
 # upload management
 upload_administration =           'Gestionar las subidas'
 mark_upload_for_removal =         'marcar para eliminación'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                'No se han encontrado archivos subidos.'
 delete_upload_confirmation =      '¿Estas seguro que quieres eliminar esta subida?'
 delete_uploads_confirmation =     '¿Estás seguro que quieres eliminar las siguientes subidas?'

--- a/lang/swedish.lang
+++ b/lang/swedish.lang
@@ -981,6 +981,8 @@ mark_upload_for_removal =         'Märk för borttagning'
 no_uploads_found =                'Hittade inga uppladdade filer.'
 delete_upload_confirmation =      'Är du säker på att du vill radera den här uppladdade filen?'
 delete_uploads_confirmation =     'Är du säker på att du vill radera de följande uppladdade filerna?'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'CAPTCHA'

--- a/lang/swedish.lang
+++ b/lang/swedish.lang
@@ -978,6 +978,7 @@ no_users_in_selection =           'Inga användare finns i detta urval'
 # upload management
 upload_administration =           'Hantering av uppladdade filer'
 mark_upload_for_removal =         'Märk för borttagning'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                'Hittade inga uppladdade filer.'
 delete_upload_confirmation =      'Är du säker på att du vill radera den här uppladdade filen?'
 delete_uploads_confirmation =     'Är du säker på att du vill radera de följande uppladdade filerna?'

--- a/lang/tamil.lang
+++ b/lang/tamil.lang
@@ -974,6 +974,7 @@ no_users_in_selection =           'தெரிவு செய்யப்ப�
 # upload management
 upload_administration =           '<!-- TODO -->Upload management'
 mark_upload_for_removal =         '<!-- TODO -->mark for removal'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                '<!-- TODO -->Found no uploaded files.'
 delete_upload_confirmation =      '<!-- TODO -->Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     '<!-- TODO -->Are you sure you want to delete the following uploads?'

--- a/lang/tamil.lang
+++ b/lang/tamil.lang
@@ -977,6 +977,8 @@ mark_upload_for_removal =         '<!-- TODO -->mark for removal'
 no_uploads_found =                '<!-- TODO -->Found no uploaded files.'
 delete_upload_confirmation =      '<!-- TODO -->Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     '<!-- TODO -->Are you sure you want to delete the following uploads?'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'CAPTCHA'

--- a/lang/turkish.lang
+++ b/lang/turkish.lang
@@ -978,6 +978,7 @@ no_users_in_selection =           'Belirli bir kullanıcı yok'
 # upload management
 upload_administration =           '<!-- TODO -->Upload management'
 mark_upload_for_removal =         '<!-- TODO -->mark for removal'
+mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                '<!-- TODO -->Found no uploaded files.'
 delete_upload_confirmation =      '<!-- TODO -->Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     '<!-- TODO -->Are you sure you want to delete the following uploads?'

--- a/lang/turkish.lang
+++ b/lang/turkish.lang
@@ -981,6 +981,8 @@ mark_upload_for_removal =         '<!-- TODO -->mark for removal'
 no_uploads_found =                '<!-- TODO -->Found no uploaded files.'
 delete_upload_confirmation =      '<!-- TODO -->Are you sure you want to delete this upload?'
 delete_uploads_confirmation =     '<!-- TODO -->Are you sure you want to delete the following uploads?'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'CAPTCHA'

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -383,10 +383,10 @@ h2#admin_header{margin:0 0 .5em 0}
 .manage-postings{border:1px solid #bacbdf;margin-top:25px;background:#f9f9f9}
 .manage-postings legend{font-size:.82em;font-weight:700}
 ul#uploadlist{list-style:none;margin:0;padding:0;max-width:100%;display:flex;flex-wrap:wrap;gap:.75em}
-#uploadlist li{width:18.5em;margin:0;padding:0;border:1px solid #bacbdf;background:#f9f9f9}
+#uploadlist > li{width:18.5em;margin:0;padding:0;border:1px solid #bacbdf;background:#f9f9f9}
 #uploadlist .image_container{padding:.5em;height:21.5em;width:100%;margin:0 0 .25em 0;text-align:center}
 #uploadlist img{max-width:100%;max-height:100%}
-#uploadlist .management_container{margin:0;padding:.25em 0}
+#uploadlist .management_container{margin:0;padding:.25em 0;list-style:none}
 #uploadlist + p{margin-block:.75em 1em}
 .confirm-selection{list-style:none;padding:0;border-top:1px solid #bacbdf}
 .confirm-selection li{min-height:2.5em;margin:0 0 .25em 0;padding:.25em .5em;border-bottom:1px solid #bacbdf}

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -1066,7 +1066,9 @@
 {section name=nr loop=$images start=$start max=$images_per_page}
   <li>
    <p class="image_container"><img src="images/uploaded/{$images[nr].pathname}" alt="{$images[nr].pathname}" /></p>
-   <p class="management_container"><input type="checkbox" id="{$images[nr].pathname}" name="uploads_remove[]" value="{$images[nr].pathname}" /><label for="{$images[nr].pathname}">{#mark_upload_for_removal#}</label></p>
+   <ul class="management_container">
+    <li><input type="checkbox" id="{$images[nr]}" name="uploads_remove[]" value="{$images[nr]}" /><label for="{$images[nr]}">{#mark_upload_for_removal#}</label></li>
+   </ul>
   </li>
 {/section}
  </ul>

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -1064,8 +1064,10 @@
 <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
  <ul id="uploadlist">
 {section name=nr loop=$images start=$start max=$images_per_page}
-  <li><p class="image_container"><img src="images/uploaded/{$images[nr]}" alt="{$images[nr]}" /></p>
-  <p class="management_container"><input type="checkbox" id="{$images[nr]}" name="uploads_remove[]" value="{$images[nr]}" /><label for="{$images[nr]}">{#mark_upload_for_removal#}</label></p></li>
+  <li>
+   <p class="image_container"><img src="images/uploaded/{$images[nr].pathname}" alt="{$images[nr].pathname}" /></p>
+   <p class="management_container"><input type="checkbox" id="{$images[nr].pathname}" name="uploads_remove[]" value="{$images[nr].pathname}" /><label for="{$images[nr].pathname}">{#mark_upload_for_removal#}</label></p>
+  </li>
 {/section}
  </ul>
  <p><input type="submit" name="delete_selected_uploads" value="{#delete#}" /></p>

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -1067,7 +1067,7 @@
   <li>
    <p class="image_container"><img src="images/uploaded/{$images[nr].pathname}" alt="{$images[nr].pathname}" /></p>
    <ul class="management_container">
-    <li><input type="checkbox" id="{$images[nr]}" name="uploads_remove[]" value="{$images[nr]}" /><label for="{$images[nr]}">{#mark_upload_for_removal#}</label></li>
+    <li><input type="checkbox" id="id-{$images[nr].number}" name="manage_uploads[]" value="{$images[nr].number}" /><label for="id-{$images[nr].number}">{#mark_upload_for_managing#}</label></li>
    </ul>
   </li>
 {/section}

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -1072,7 +1072,9 @@
   </li>
 {/section}
  </ul>
- <p><input type="submit" name="delete_selected_uploads" value="{#delete#}" /></p>
+ <div>
+  <button name="delete_selected_uploads" value="{#delete#}">{#delete#}</button>
+ </div>
 </form>
 
 {if $pagination}


### PR DESCRIPTION
Currently the upload management in the admin area lists all images and make it possible to select multiple images of an image-list-page for removal from the file system. That's all.

Managing images should be more than this. Since version 20220508.1 the forum software stores informations about the uploaded images in a database table (user-id of the uploading user (`NULL` for not registered users), filename, time of uploading). For providing information in example about the use of an image in postings in the future, the managment UI must be flexible and not directed to *one* certain function.

For this reason, I have extended the `$images` array, renamed the checkbox and also made the label text a little more general. This serves to prepare for the expansion of the upload management functionality.