### PR TITLE
Add missing strings to the Arabic translation

### DIFF
--- a/lang/arabic.lang
+++ b/lang/arabic.lang
@@ -978,6 +978,8 @@ mark_upload_for_managing =        '<!-- TODO -->mark for managing'
 no_uploads_found =                'لم يتم العثور على أي ملفات مرفوعة.'
 delete_upload_confirmation =      'هل أنت متأكد أنك تريد حذف هذا التحميل؟'
 delete_uploads_confirmation =     'هل أنت متأكد أنك تريد حذف التحميلات التالية؟'
+check_for_unrecorded_uploads =    '<!-- TODO -->record uploads'
+check_for_unrecorded_uploads_desc = '<!-- TODO -->Check whether there are any uploads that are not yet included in the list of uploads. If any are found, they are entered in the list.'
 
 # spam protection:
 captcha =                         'الصورة الإختباريّة'


### PR DESCRIPTION
Those was untranslated because of the non existing arabic translation at the time of adding them to the other languages.