### PR TITLE
Fixes for the upload management enhancements

### DIFF
--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -964,7 +964,7 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 		if (isset($_POST['selected_confirmed'])) {
 			foreach ($_POST['selected_confirmed'] as $upload_rm) {
 				$qDelUploadEntry = "DELETE FROM ". $db_settings['uploads_table'] ."
-				WHERE filename = '". mysqli_real_escape_string($connid, $upload_rm) ."'";
+				WHERE pathname = '". mysqli_real_escape_string($connid, $upload_rm) ."'";
 				$rDelUploadEntry = mysqli_query($connid, $qDelUploadEntry);
 				if ($rDelUploadEntry !== false) {
 					$path_rm = 'images/uploaded/'. $upload_rm;

--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -1036,7 +1036,7 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 			if (preg_match('/\.(gif|png|jpe?g|svg|webp)$/i', $file)) {
 				$images[$i]['number'] = $i;
 				$images[$i]['pathname'] = $file;
-				if (!empty($listed) && !in_array($file, $listed)) {
+				if (empty($listed) || (!empty($listed) && !in_array($file, $listed))) {
 					$images[$i]['status'] = 0;
 				} else {
 					$images[$i]['status'] = 1;


### PR DESCRIPTION
There was two bugs in the merged code for pull request #789.

1. When checking the entries in the database against the array of uploaded images, all images was marked as managed in the uploads table in case of not a single entry in this table. The code has not taken this case of an empty result of the table query into account.
2. The code to delete (a) selected image(s) should delete also the entry for an image, if present. The query searched the filename in the column `filename` which was renamed to `pathname`. This led to a silent database error, what led to `mysqli_query` returning `false`, what led to not fulfilling the requirement `if ($rDelUploadEntry !== false)` to delete the image file from the file system.

The two commits in this PR fixes these bugs.