### PR TITLE
Correct a spelling mistake in the German language

### DIFF
--- a/lang/german.lang
+++ b/lang/german.lang
@@ -1066,7 +1066,7 @@ update_submit =                   'OK – Update ausführen'
 update_successful =               'Die Datenbank wurde erfolgreich aktualisiert.'
 update_items_note =               'Bitte jetzt die folgenden Dateien/Verzeichnisse der neuen Version ([version]) hochladen:'
 update_download =                 'Falls nicht verfügbar, können diese Dateien [[hier]] heruntergeladen werden.'
-update_reenabling_notice =        'Bitte zu beachten, dass das Forum aktuell reaktiviert ist und <a href="index.php?mode=admin&action=settings">in den Einstellungen</a> wieder eingeschaltet werden muss.'
+update_reenabling_notice =        'Bitte zu beachten, dass das Forum aktuell deaktiviert ist und <a href="index.php?mode=admin&action=settings">in den Einstellungen</a> wieder eingeschaltet werden muss.'
 
 [emails]
 email_subject =                   'Antwort auf "[original_subject]"'


### PR DESCRIPTION
Correct a spelling mistake that distorts the meaning of the sentence about the forums status during the upgrade process. The sentence states that the forum is *re*activated (*re*aktiviert), although the forum is ***de***activated (***de***aktiviert).