### PR TITLE
Fix #790: apply the changes to the template for sending an e-mail in case of a forgotten password

### DIFF
--- a/themes/default/subtemplates/login_pw_forgotten.inc.tpl
+++ b/themes/default/subtemplates/login_pw_forgotten.inc.tpl
@@ -4,7 +4,7 @@
   <input type="hidden" name="mode" value="login" />
   <div>
    <label for="pwf_email" class="main">{#pwf_email#}</label>
-   <input id="pwf_email" type="email" name="pwf_email" size="30" />
+   <input id="pwf_email" type="email" name="pwf_email" size="30" autofocus required />
   </div>
   <div>
    <button name="pwf_submit" value="{#submit_button_ok#}">{#submit_button_ok#}</button>

--- a/themes/default/subtemplates/login_pw_forgotten.inc.tpl
+++ b/themes/default/subtemplates/login_pw_forgotten.inc.tpl
@@ -4,7 +4,7 @@
   <input type="hidden" name="mode" value="login" />
   <div>
    <label for="pwf_email" class="main">{#pwf_email#}</label>
-   <input id="pwf_email" type="text" name="pwf_email" size="30" />
+   <input id="pwf_email" type="email" name="pwf_email" size="30" />
   </div>
   <div>
    <button name="pwf_submit" value="{#submit_button_ok#}">{#submit_button_ok#}</button>


### PR DESCRIPTION
Added the attributes `autofocus` and `required` to the input field for the e-mail-address and changed its type from `text` to `email`.

Fixes #790