### PR TITLE
Fix for wrong column name "filename" in the uploads management table

### DIFF
--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -93,7 +93,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 			@chmod($uploaded_images_path.$filename, 0644);
 			// $user_id can be NULL (see around line #15), because of that do not handle it with intval()
 			// see therefore variable definition of $user_id around line 15 of this script
-			$qSetUpload = "INSERT INTO " . $db_settings['uploads_table'] . " (uploader, filename, tstamp) VALUES (". $user_id .", '" . mysqli_real_escape_string($connid, $filename) . "', NOW())";
+			$qSetUpload = "INSERT INTO " . $db_settings['uploads_table'] . " (uploader, pathname, tstamp) VALUES (". $user_id .", '" . mysqli_real_escape_string($connid, $filename) . "', NOW())";
 			mysqli_query($connid, $qSetUpload);
 			$smarty->assign('uploaded_file', $filename);
 		} else {


### PR DESCRIPTION
 I replaced the column name "filename" with the new name "pathname" with the latest upgrade to version 20250323.1. The purpose is to describe with the column name, that the column can not only store filenames but also relative paths for the cae of splitting the directories for uploads to yearly or monthly dirs. For details see also #789 and #798.

Doing this I missed one query with the old column name. The project forum user Fritz [reported the bug](https://mylittleforum.net/forum/index.php?id=18918) in the project forum (in German language).