### PR TITLE
Rework of the forum upgrade, reset and uninstallation admin password forms

### DIFF
--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -867,7 +867,7 @@
  <input type="hidden" name="mode" value="admin" />
  <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
  <div>
-  <label for="confirm_pw_uninstall" class="main">{#reset_uninstall_conf_pw#}</label>
+  <label for="confirm_pw_uninstall" class="main">{#admin_confirm_password#}</label>
   <input type="password" id="confirm_pw_uninstall" name="confirm_pw" spellcheck="false" autocomplete="off" writingsuggestions="false" size="20" />
  </div>
  <div class="buttonbar">

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -864,12 +864,15 @@
 <h2>{#uninstall_forum#}</h2>
 <p>{#uninstall_forum_exp#}</p>
 <form action="index.php" method="post" accept-charset="{#charset#}">
-<div>
-<input type="hidden" name="mode" value="admin" />
-<input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
-<p>{#reset_uninstall_conf_pw#}<br />
-<input type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="20" name="confirm_pw" /> <input type="submit" name="uninstall_forum_confirmed" value="{#uninstall_forum_submit#}" /></p>
-</div>
+ <input type="hidden" name="mode" value="admin" />
+ <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
+ <div>
+  <label for="confirm_pw_uninstall" class="main">{#reset_uninstall_conf_pw#}</label>
+  <input type="password" id="confirm_pw_uninstall" name="confirm_pw" spellcheck="false" autocomplete="off" writingsuggestions="false" size="20" />
+ </div>
+ <div class="buttonbar">
+  <button name="uninstall_forum_confirmed" value="{#uninstall_forum_submit#}">{#uninstall_forum_submit#}</button>
+ </div>
 </form>
 {elseif $action=='update'}
 <p style="margin-bottom:25px;"><span style="background:yellow; padding:5px;">{#update_current_version#|replace:"[version]":$settings.version}</span></p>

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -842,14 +842,21 @@
 
 <h2>{#reset_forum#}</h2>
 <form action="index.php" method="post" accept-charset="{#charset#}">
-<div>
-<input type="hidden" name="mode" value="admin" />
-<input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
-<p><input id="delete_postings" type="checkbox" name="delete_postings" value="true" /><label for="delete_postings"> {#delete_postings#}</label></p>
-<p><input id="delete_userdata" type="checkbox" name="delete_userdata" value="true" /><label for="delete_userdata"> {#delete_userdata#}</label></p>
-<p>{#admin_confirm_password#}<br />
-<input type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="20" name="confirm_pw" /> <input type="submit" name="reset_forum_confirmed" value="{#reset_forum_submit#}" /></p>
-</div>
+ <input type="hidden" name="mode" value="admin" />
+ <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
+ <div>
+  <ul class="checkboxlist">
+   <li><input id="delete_postings" type="checkbox" name="delete_postings" value="true" /><label for="delete_postings"> {#delete_postings#}</label></li>
+   <li><input id="delete_userdata" type="checkbox" name="delete_userdata" value="true" /><label for="delete_userdata"> {#delete_userdata#}</label></li>
+  </ul>
+ </div>
+ <div>
+  <label for="confirm_pw_reset" class="main">{#admin_confirm_password#}</label>
+  <input type="password" id="confirm_pw_reset" name="confirm_pw" spellcheck="false" autocomplete="off" writingsuggestions="false" size="20" />
+ </div>
+ <div class="buttonbar">
+  <button name="reset_forum_confirmed" value="{#reset_forum_submit#}">{#reset_forum_submit#}</button>
+ </div>
 </form>
 
 <hr style="margin:20px 0px 20px 0px; border-top: 1px dotted #808080; border-left: 0; border-right: 0; border-bottom: 0; height: 1px;"/>

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -893,12 +893,13 @@
 <p style="color:red;font-weight:bold;">{#update_note#}</p>
 {if $errors}{include file="$theme/subtemplates/errors.inc.tpl"}{/if}
 <form action="index.php" method="post" accept-charset="{#charset#}">
-<div>
-<input type="hidden" name="mode" value="admin" />
-<input type="hidden" name="update_file_submit" value="{$update_file}" />
-<input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
-<p>{#admin_confirm_password#}<br /><input type="password" name="update_password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25"/></p>
-</div>
+ <input type="hidden" name="mode" value="admin" />
+ <input type="hidden" name="update_file_submit" value="{$update_file}" />
+ <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
+ <div>
+  <label for="id_update_password">{#admin_confirm_password#}</label>
+  <input type="password" name="update_password" id="id_update_password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" />
+ </div>
  <div class="buttonbar">
   <button name="update_submit" value="{#update_submit#}" onclick="document.getElementById('throbber-submit').removeAttribute('hidden');">{#update_submit#}</button>
   <img id="throbber-submit" src="{$THEMES_DIR}/{$theme}/images/throbber.svg" alt="" width="18" height="18" hidden />


### PR DESCRIPTION
All of the forms had their pitfalls like missing labels or the use of non existing language strings for a non-label (double issue). Corrected the string for the label, added the labels, where they were missing, reformatted the HTML-sources and replaced the inputs of the type `submit` with buttons. 