### PR TITLE
Fix issue 806, remove a superfluous comma

### DIFF
--- a/themes/default/subtemplates/entry.inc.tpl
+++ b/themes/default/subtemplates/entry.inc.tpl
@@ -30,7 +30,7 @@
 <h1>{$subject}{if $category_name} <span class="category">({$category_name})</span>{/if}</h1>
 <p class="author">{if $location}{#posted_by_location#|replace:"[name]":$name|replace:"[email_hp]":$email_hp|replace:"[location]":$location}{else}{#posted_by#|replace:"[name]":$name|replace:"[email_hp]":$email_hp}{/if} <time datetime="{$ISO_time}">{*{assign var=formated_time value=$disp_time|date_format:#time_format_full#}*}{$formated_time}</time> <span class="ago">({if $ago.days>1}{#posting_several_days_ago#|replace:"[days]":$ago.days_rounded}{else}{if $ago.days==0 && $ago.hours==0}{#posting_minutes_ago#|replace:"[minutes]":$ago.minutes}{elseif $ago.days==0 && $ago.hours!=0}{#posting_hours_ago#|replace:"[hours]":$ago.hours|replace:"[minutes]":$ago.minutes}{else}{#posting_one_day_ago#|replace:"[hours]":$ago.hours|replace:"[minutes]":$ago.minutes}{/if}{/if})</span>{if $admin && $ip} <span class="ip">({$ip})</span>{/if}{if $pid!=0} <span class="op-link"><a href="index.php?id={$pid}" title="{#original_posting_linktitle#|replace:"[name]":$data.$pid.name}">@ {$data.$pid.name}</a></span>{/if}
 {if $edited}{*{assign var=formated_edit_time value=$edit_time|date_format:#time_format_full#}*}<br />
-<span class="edited">{#edited_by#|replace:"[name]":$edited_by}, <time datetime="{$edit_ISO_time}">{$formated_edit_time}</time></span>{/if}</p>
+<span class="edited">{#edited_by#|replace:"[name]":$edited_by}<time datetime="{$edit_ISO_time}">{$formated_edit_time}</time></span>{/if}</p>
 </header>
 <div class="wrapper">
 <div class="body">


### PR DESCRIPTION
Remove the superfluous comma, mentioned in #806. It's already present in the translation strings and has not to be repeated in the template.