### PR TITLE
Replace the old RSS icon with a SVG icon

### DIFF
--- a/themes/default/images/rss-logo.svg
+++ b/themes/default/images/rss-logo.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" standalone="yes"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="264" height="264" viewBox="0 0 264 264">
+ <defs>
+  <linearGradient id="plate" x1="100%" y1="0%" x2="0%" y2="100%">
+   <stop offset="0%" stop-color="#ecbf1f" />
+   <stop offset="100%" stop-color="#d4a400" />
+  </linearGradient>
+  <linearGradient id="bordershadow" x1="0%" y1="0%" x2="100%" y2="100%">
+   <stop offset="0%" stop-color="#efe6af" />
+   <stop offset="17.5%" stop-color="#eed734" />
+   <stop offset="42.5%" stop-color="#ebd32c" />
+   <stop offset="57.5%" stop-color="#bc8c02" />
+   <stop offset="82.5%" stop-color="#b08400" />
+   <stop offset="100%" stop-color="#904200" />
+  </linearGradient>
+ </defs>
+ <style type="text/css">
+  <![CDATA[
+  svg { fill: transparent; }
+  rect { stroke: none; fill: url(#plate); }
+  g circle { stroke: none; fill: #fff; }
+  path { fill: none; stroke-width: 34.5; stroke: #fff; stroke-linecap: round; }
+  #border { fill: url(#bordershadow); stroke: none; }
+  ]]>
+ </style>
+ <g transform="scale(0.9)" transform-origin="center">
+  <g>
+   <rect x="1" y="1" width="262" height="262" rx="53" ry="53" />
+   <path id="border" d="M 1,54 A 53 53, 0, 0, 1 54,1 L 210,1 A 53 53, 0, 0, 1 263,54 L 263,210 A 53 53, 0, 0, 1 210,263 L 54,263 A 53 53, 0, 0, 1 1,210 z M 16,54 L 16,210 A 38 38, 0, 0, 0 54,248 L 210,248 A 38 38, 0, 0, 0 248,210 L 248,54 A 38 38, 0, 0, 0 210,16 L 54,16 A 38 38, 0, 0, 0 16,54 z" />
+  </g>
+  <g>
+   <circle cx="54" cy="210" r="25" />
+   <path d="M 54,132 A 78 78, 0, 0, 1, 132,210" />
+   <path d="M 54,54 A 160 160, 0, 0, 1, 210,210" />
+  </g>
+ </g>
+</svg>

--- a/themes/default/main.tpl
+++ b/themes/default/main.tpl
@@ -96,9 +96,9 @@ window.MathJax = {
 <div id="footerlinklist">
 <ul id="footermenu">
  <li><a href="#top" class="go-to-top-link" title="{#back_to_top_link_title#}">{#back_to_top_link#}</a></li>
-{if $settings.rss_feed==1} <li><a class="rss" href="index.php?mode=rss" title="{#rss_feed_postings_title#}">{#rss_feed_postings#}</a></li>
- <li><a class="rss" href="index.php?mode=rss&amp;items=thread_starts" title="{#rss_feed_new_threads_title#}">{#rss_feed_new_threads#}</a></li>{/if}
  <li><a href="index.php?mode=contact" title="{#contact_linktitle#}" rel="nofollow">{#contact_link#}</a></li>
+{if $settings.rss_feed==1} <li><a href="index.php?mode=rss" title="{#rss_feed_postings_title#}"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/rss-logo.svg" alt="" width="14" height="14"/><span>{#rss_feed_postings#}</span></a></li>
+ <li><a href="index.php?mode=rss&amp;items=thread_starts" title="{#rss_feed_new_threads_title#}"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/rss-logo.svg" alt="" width="14" height="14"/><span>{#rss_feed_new_threads#}</span></a></li>{/if}
 </ul>
 </div>
 {*

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -10,6 +10,7 @@ a:visited{color:#00c}
 a:focus,a:hover{color:#00f;text-decoration:underline}
 a:active{color:red}
 a.stronglink{color:#00c;text-decoration:none;font-weight:700;background:url(images/bg_sprite_1.png) no-repeat}
+a:has(img.icon){display:flex;align-items:center;gap:.125em}
 html[dir="ltr"] a.stronglink{padding-left:13px;background-position:left 4px}
 html[dir="rtl"] a.stronglink{padding-right:13px;background-position:right -1306px}
 a.stronglink:visited{color:#00c}
@@ -72,9 +73,6 @@ html[dir="rtl"] #subnavmenu a.linear{background-position-x:calc(100% + 5px)}
 html[dir="rtl"] #subnavmenu a.hierarchic{background-position-x:calc(100% + 5px)}
 #subnavmenu a.fold-postings{padding-inline-start:13px;background:url(images/bg_sprite_1.png) no-repeat 0 -998px}
 html[dir="rtl"] #subnavmenu a.fold-postings{background-position-x:calc(100% + 5px)}
-a.rss{background:url(images/bg_sprite_1.png) no-repeat 2px -1048px}
-html[dir="rtl"] a.rss{background-position-x:calc(100% + 4px)}
-p.right a.rss{padding-inline-start:15px}
 input.small,select.small{font-size:.82em}
 #content{margin:0;padding:1em;padding:1rem;line-height:1.5;background:#fff;flex:1;overflow:auto}
 #content p,#content ul,#content td,#postingform{font-size:.82em;max-width:60em}
@@ -89,7 +87,6 @@ input.small,select.small{font-size:.82em}
 #footermenu li{margin:0}
 #footermenu li:not(:last-child):after{content: "|"}
 #footermenu li:not(:last-child) a{margin-inline-end:.4em}
-#footermenu li a.rss{padding-inline-start:15px}
 #footermenu a.go-to-top-link{padding-inline-start:12px}
 html[dir="ltr"] #footermenu a.go-to-top-link{background:url(images/arrow_up.png) no-repeat 0 0 / auto 90%}
 html[dir="rtl"] #footermenu a.go-to-top-link{background:url(images/arrow_up.png) no-repeat 100% 0 / auto 90%}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -85,11 +85,10 @@ input.small,select.small{font-size:.82em}
 #footerlinklist{grid-area:footerlinks}
 #footermenu{margin:0;padding:0;list-style-type:none;display:flex;flex-wrap:wrap;gap:3px .4em}
 #footermenu li{margin:0}
-#footermenu li:not(:last-child):after{content: "|"}
-#footermenu li:not(:last-child) a{margin-inline-end:.4em}
 #footermenu a.go-to-top-link{padding-inline-start:12px}
 html[dir="ltr"] #footermenu a.go-to-top-link{background:url(images/arrow_up.png) no-repeat 0 0 / auto 90%}
 html[dir="rtl"] #footermenu a.go-to-top-link{background:url(images/arrow_up.png) no-repeat 100% 0 / auto 90%}
+#footermenu li:not(:last-child){border-inline-end:1px solid #000;padding-inline-end:.4em}
 #pbmlf{text-align:center;font-size:.69em;color:gray;grid-area:projectlink}
 #pbmlf a{color:gray;text-decoration:none}
 #main-grid{display:grid;grid-template-columns:calc(100vw - 2em);grid-template-rows:auto auto;gap:.75em;grid-template-areas:"sidebar" "threadlist"}

--- a/themes/default/subtemplates/entry.inc.tpl
+++ b/themes/default/subtemplates/entry.inc.tpl
@@ -72,7 +72,8 @@
 
 <hr class="entryline" />
 <div class="complete-thread">
-<p class="left"><strong>{#complete_thread_marking#}</strong></p><p class="right">&nbsp;{if $settings.rss_feed==1}<a class="rss" href="index.php?mode=rss&amp;thread={$tid}" title="{#rss_feed_thread_title#}">{#rss_feed_thread#}</a>{/if}</p>
+<p class="left"><strong>{#complete_thread_marking#}</strong></p>
+<p class="right">&nbsp;{if $settings.rss_feed==1}<a href="index.php?mode=rss&amp;thread={$tid}" title="{#rss_feed_thread_title#}"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/rss-logo.svg" alt="" width="14" height="14"/><span>{#rss_feed_thread#}</span></a>{/if}</p>
 </div>
 
 <ul class="thread openthread">

--- a/themes/default/subtemplates/thread.inc.tpl
+++ b/themes/default/subtemplates/thread.inc.tpl
@@ -88,5 +88,5 @@
 {/function}
 {tree element=$tid}
 {if $settings.rss_feed==1}<div class="complete-thread">
-<p class="right"><a class="rss" href="index.php?mode=rss&amp;thread={$tid}" title="{#rss_feed_thread_title#}">{#rss_feed_thread#}</a></p>
+<p class="right"><a href="index.php?mode=rss&amp;thread={$tid}" title="{#rss_feed_thread_title#}"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/rss-logo.svg" alt="" width="14" height="14"/><span>{#rss_feed_thread#}</span></a></p>
 </div>{/if}

--- a/themes/default/subtemplates/thread_linear.inc.tpl
+++ b/themes/default/subtemplates/thread_linear.inc.tpl
@@ -84,5 +84,5 @@
 {/foreach}
 </div>
 {if $settings.rss_feed==1}<div class="complete-thread">
-<p class="right"><a class="rss" href="index.php?mode=rss&amp;thread={$tid}" title="{#rss_feed_thread_title#}">{#rss_feed_thread#}</a></p>
+<p class="right"><a href="index.php?mode=rss&amp;thread={$tid}" title="{#rss_feed_thread_title#}"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/rss-logo.svg" alt="" width="14" height="14"/><span>{#rss_feed_thread#}</span></a></p>
 </div>{/if}


### PR DESCRIPTION
With replacing this icon that is in use in a link list in the page footer as well as below the postings outside a list was an opportunity to create a standardized infrastructure for icons on links and buttons, which can be assigned to the icons now stored in HTML instead of as CSS background images by assigning the class `icon` to the images.

Additionally, with adding the icons to the HTML sources, the fiddling with repositioning of icons as background images in the CSS source for right to left written languages will have an end when done.