### PR TITLE
Unifying the thread locking links in the options list for postings

### DIFF
--- a/includes/entry.inc.php
+++ b/includes/entry.inc.php
@@ -51,6 +51,16 @@
 			$entrydata = mysqli_fetch_array($result);
 			mysqli_free_result($result);
 			
+			$tl_result = mysqli_query($connid, "SELECT MIN(locked) AS thread_locked
+			FROM " . $db_settings['forum_table'] . "
+			WHERE tid = ". intval($entrydata["tid"]));
+			if ($tl_result ==! false) {
+				$tl_data = mysqli_fetch_assoc($tl_result);
+				$entrydata['thread_locked'] = ($tl_data['thread_locked'] == 0) ? 0 : 1;
+			} else {
+				$entrydata['thread_locked'] = 1;
+			}
+			
 			$entrydata['ISO_time']      = format_time('YYYY-MM-dd HH:mm:ss', $entrydata['time']);
 			$entrydata['edit_ISO_time'] = format_time('YYYY-MM-dd HH:mm:ss', $entrydata['etime']);
 			$entrydata['formated_time'] = format_time($lang['time_format_full'], $entrydata['disp_time']);
@@ -253,6 +263,7 @@
 	$smarty->assign('ISO_time',  htmlspecialchars($entrydata['ISO_time']));
 	$smarty->assign('formated_time', htmlspecialchars($entrydata['formated_time']));
 	$smarty->assign('locked', htmlspecialchars($entrydata['locked']));
+	$smarty->assign('thread_locked', htmlspecialchars($entrydata['thread_locked']));
 	
 	$ago['days']    = floor((TIMESTAMP - $entrydata['time']) / 86400);
 	$ago['hours']   = floor(((TIMESTAMP - $entrydata['time']) / 3600) - ($ago['days'] * 24));

--- a/includes/thread.inc.php
+++ b/includes/thread.inc.php
@@ -96,6 +96,16 @@ if (is_array($category_ids) && !in_array($data['category'], $category_ids)) {
 	$result = mysqli_query($connid, $thread_sql) or raise_error('database_error', mysqli_error($connid));
 	
 	if (mysqli_num_rows($result) > 0) {
+		$tl_result = mysqli_query($connid, "SELECT MIN(locked) AS thread_locked
+		FROM " . $db_settings['forum_table'] ."
+		WHERE tid = ". intval($tid));
+		if ($tl_result ==! false) {
+			$tl_data = mysqli_fetch_assoc($tl_result);
+			$thread_locked = ($tl_data['thread_locked'] == 0) ? 0 : 1;
+		} else {
+			$thread_locked = 1;
+		}
+		
 		while ($data = mysqli_fetch_array($result)) {
 			
 			// tags:
@@ -118,6 +128,7 @@ if (is_array($category_ids) && !in_array($data['category'], $category_ids)) {
 			}
 			$data['formated_time'] = format_time($lang['time_format_full'], $data['disp_time']);
 			$data['ISO_time']      = format_time('YYYY-MM-dd HH:mm:ss', $data['time']);
+			$data['thread_locked'] = $thread_locked;
 			
 			$ago['days']           = floor((TIMESTAMP - $data['time']) / 86400);
 			$ago['hours']          = floor(((TIMESTAMP - $data['time']) / 3600) - ($ago['days'] * 24));

--- a/themes/default/subtemplates/entry.inc.tpl
+++ b/themes/default/subtemplates/entry.inc.tpl
@@ -63,8 +63,12 @@
 {if $options.report_spam}<li><a href="index.php?mode=posting&amp;report_spam={$id}&amp;back=entry" class="report-spam" title="{#report_spam_linktitle#}">{#report_spam_linkname#}</a></li>{/if}
 {if $options.flag_ham}<li><a href="index.php?mode=posting&amp;flag_ham={$id}&amp;back=entry" class="report-ham" title="{#flag_ham_linktitle#}">{#flag_ham_linkname#}</a></li>{/if}
 {if $options.lock}<li><a href="index.php?mode=posting&amp;lock={$id}&amp;back=entry" class="{if $locked==0}lock{else}unlock{/if}" title="{if $locked==0}{#lock_linktitle#}{else}{#unlock_linktitle#}{/if}">{if $locked==0}{#lock_linkname#}{else}{#unlock_linkname#}{/if}</a></li>
+{if $thread_locked == 1}
+<li><a href="index.php?mode=posting&amp;unlock_thread={$id}&amp;back=entry" class="unlock-thread" title="{#unlock_thread_linktitle#}">{#unlock_thread_linkname#}</a></li>
+{else}
 <li><a href="index.php?mode=posting&amp;lock_thread={$id}&amp;back=entry" class="lock-thread" title="{#lock_thread_linktitle#}">{#lock_thread_linkname#}</a></li>
-<li><a href="index.php?mode=posting&amp;unlock_thread={$id}&amp;back=entry" class="unlock-thread" title="{#unlock_thread_linktitle#}">{#unlock_thread_linkname#}</a></li>{/if}
+{/if}
+{/if}
 </ul>
 {/if}
 </footer>

--- a/themes/default/subtemplates/thread.inc.tpl
+++ b/themes/default/subtemplates/thread.inc.tpl
@@ -75,8 +75,14 @@
 {if $data.$element.options.report_spam}<li><a href="index.php?mode=posting&amp;report_spam={$data.$element.id}&amp;back=thread" class="report-spam" title="{#report_spam_linktitle#}">{#report_spam_linkname#}</a></li>{/if}
 {if $data.$element.options.flag_ham}<li><a href="index.php?mode=posting&amp;flag_ham={$data.$element.id}&amp;back=thread" class="report-ham" title="{#flag_ham_linktitle#}">{#flag_ham_linkname#}</a></li>{/if}
 {if $data.$element.options.lock}<li><a href="index.php?mode=posting&amp;lock={$data.$element.id}&amp;back=thread" class="{if $data.$element.locked==0}lock{else}unlock{/if}" title="{if $data.$element.locked==0}{#lock_linktitle#}{else}{#unlock_linktitle#}{/if}">{if $data.$element.locked==0}{#lock_linkname#}{else}{#unlock_linkname#}{/if}</a></li>
-{if $data.$element.pid==0}<li><a href="index.php?mode=posting&amp;lock_thread={$data.$element.id}&amp;back=thread" class="lock-thread" title="{#lock_thread_linktitle#}">{#lock_thread_linkname#}</a></li>
-<li><a href="index.php?mode=posting&amp;unlock_thread={$data.$element.id}&amp;back=thread" class="lock-thread" title="{#unlock_thread_linktitle#}">{#unlock_thread_linkname#}</a></li>{/if}{/if}
+{if $data.$element.pid==0}
+{if $data.$element.thread_locked == 1}
+<li><a href="index.php?mode=posting&amp;unlock_thread={$data.$element.id}&amp;back=thread" class="unlock-thread" title="{#unlock_thread_linktitle#}">{#unlock_thread_linkname#}</a></li>
+{else}
+<li><a href="index.php?mode=posting&amp;lock_thread={$data.$element.id}&amp;back=thread" class="lock-thread" title="{#lock_thread_linktitle#}">{#lock_thread_linkname#}</a></li>
+{/if}
+{/if}
+{/if}
 </ul>
 {/if}
 </footer>

--- a/themes/default/subtemplates/thread_linear.inc.tpl
+++ b/themes/default/subtemplates/thread_linear.inc.tpl
@@ -75,8 +75,14 @@
 {if $element.options.report_spam}<li><a href="index.php?mode=posting&amp;report_spam={$element.id}&amp;back=thread" class="report-spam" title="{#report_spam_linktitle#}">{#report_spam_linkname#}</a></li>{/if}
 {if $element.options.flag_ham}<li><a href="index.php?mode=posting&amp;flag_ham={$element.id}&amp;back=thread" class="report-ham" title="{#flag_ham_linktitle#}">{#flag_ham_linkname#}</a></li>{/if}
 {if $element.options.lock}<li><a href="index.php?mode=posting&amp;lock={$element.id}&amp;back=thread" class="{if $element.locked==0}lock{else}unlock{/if}" title="{if $element.locked==0}{#lock_linktitle#}{else}{#unlock_linktitle#}{/if}">{if $element.locked==0}{#lock_linkname#}{else}{#unlock_linkname#}{/if}</a></li>
-{if $element.pid==0}<li><a href="index.php?mode=posting&amp;lock_thread={$element.id}&amp;back=thread" class="lock-thread" title="{#lock_thread_linktitle#}">{#lock_thread_linkname#}</a></li>
-<li><a href="index.php?mode=posting&amp;unlock_thread={$element.id}&amp;back=thread" class="lock-thread" title="{#unlock_thread_linktitle#}">{#unlock_thread_linkname#}</a></li>{/if}{/if}
+{if $element.pid==0}
+{if $element.thread_locked == 1}
+<li><a href="index.php?mode=posting&amp;unlock_thread={$id}&amp;back=entry" class="unlock-thread" title="{#unlock_thread_linktitle#}">{#unlock_thread_linkname#}</a></li>
+{else}
+<li><a href="index.php?mode=posting&amp;lock_thread={$id}&amp;back=entry" class="lock-thread" title="{#lock_thread_linktitle#}">{#lock_thread_linkname#}</a></li>
+{/if}
+{/if}
+{/if}
 </ul>
 {/if}
 </footer>


### PR DESCRIPTION
One thing, that triggered me since ages, is the doubling of the links to lock or unkock the complete thread under postings. In the single posting view every single posting repeats these two links, in the threaded views only the opening posting provides these links.


![Screenshot of the posting options list with the currently three locing and unlocking links](https://github.com/user-attachments/assets/c35e6553-7be4-4da0-a450-7d6b11a9b787)

The left locking link, named "lock" would lock only the posting and if the posting is locked, it changes it's name to "unlock". The two links on the right-hand side of the screenshot are the links for locking and unlocking the entire thread, which is what this is about. 

Once, *before* he created the MLF-repository on Github, I submitted Alex a diff of a patch to unify the two links into one but he rejected the patch with a reason that I don't remember. Regardless of his reasoning, which can no longer be reconstructed, I think it makes sense to only display the lock link if the thread is not locked or only the unlock link if the thread is locked.

Now, an estimated 12+ years later, I would like to make another attempt.

The status of the thread being locked or not is determined by querying whether one, several or all of the postings in the thread are not locked. The thread is only considered locked if *all* postings are locked. Depending of the determined state, only the lock or the unlock link will be displayed.

Maybe it is a good idea to also rename the lock posting link (currently only "lock") to "lock posting" and also it's pendant "unlock" to "unlock posting".