### PR TITLE
SVG icons for the moderation menu

### DIFF
--- a/themes/default/images/manage-marked-postings.svg
+++ b/themes/default/images/manage-marked-postings.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" standalone="yes"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="264" height="264" viewBox="0 0 264 264">
+ <style type="text/css">
+  <![CDATA[
+  svg { fill: transparent; }
+  #container { fill: #fff; stroke-width: 24; stroke: #bbb; stroke-linejoin: round; }
+  #lines { fill: none; stroke-width: 20; stroke: #222; stroke-linecap: round; }
+  ]]>
+ </style>
+ <g>
+  <path id="container" d="M12,72 a30 30, 0, 0, 1, 30,-30 h180 a30 30, 0, 0, 1, 30,30 v120 a30 30, 0, 0, 1, -30,30 h-180 a30 30, 0, 0, 1, -30,-30 z" />
+  <path id="lines" d="M60,90 h144 m-144,42 h144 m-144,42 h144" />
+ </g>
+</svg>
+

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -486,12 +486,6 @@ h2.sidebar a:active {
 #mod-options a span {
 	padding-inline-start: 16px;
 }
-#mod-options a.delete-marked {
-	background: url(images/bg_sprite_4.png) no-repeat .375em -293px;
-}
-html[dir="rtl"] #mod-options a.delete-marked {
-	background-position-x: calc(100% - .375em);
-}
 #mod-options a.manage {
 	background: url(images/bg_sprite_4.png) no-repeat .375em -344px;
 }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -486,12 +486,6 @@ h2.sidebar a:active {
 #mod-options a span {
 	padding-inline-start: 16px;
 }
-#mod-options a.delete-spam {
-	background: url(images/bg_sprite_3.png) no-repeat .375em -45px;
-}
-html[dir="rtl"] #mod-options a.delete-spam {
-	background-position-x: calc(100% - .375em);
-}
 input[name=sort_of_agreement] + iframe {
 	height: 400px;
 	height: 60vh;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -483,8 +483,6 @@ h2.sidebar a:active {
 	padding-inline: 0.375em;
 	display: block;
 }
-#mod-options a span {
-	padding-inline-start: 16px;
 }
 input[name=sort_of_agreement] + iframe {
 	height: 400px;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -481,8 +481,6 @@ h2.sidebar a:active {
 }
 #mod-options a {
 	padding-inline: 0.375em;
-	display: block;
-}
 }
 input[name=sort_of_agreement] + iframe {
 	height: 400px;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -486,12 +486,6 @@ h2.sidebar a:active {
 #mod-options a span {
 	padding-inline-start: 16px;
 }
-#mod-options a.manage {
-	background: url(images/bg_sprite_4.png) no-repeat .375em -344px;
-}
-html[dir="rtl"] #mod-options a.manage {
-	background-position-x: calc(100% - .375em);
-}
 #mod-options a.report {
 	background: url(images/bg_sprite_4.png) no-repeat .375em -45px;
 }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -486,12 +486,6 @@ h2.sidebar a:active {
 #mod-options a span {
 	padding-inline-start: 16px;
 }
-#mod-options a.report {
-	background: url(images/bg_sprite_4.png) no-repeat .375em -45px;
-}
-html[dir="rtl"] #mod-options a.report {
-	background-position-x: calc(100% - .375em);
-}
 #mod-options a.delete-spam {
 	background: url(images/bg_sprite_3.png) no-repeat .375em -45px;
 }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -510,12 +510,6 @@ html[dir="rtl"] #mod-options a.report {
 html[dir="rtl"] #mod-options a.delete-spam {
 	background-position-x: calc(100% - .375em);
 }
-#mod-options a.non-activated-users {
-	background: url(images/bg_sprite_4.png) no-repeat .375em -393px;
-}
-html[dir="rtl"] #mod-options a.non-activated-users {
-	background-position-x: calc(100% - .375em);
-}
 input[name=sort_of_agreement] + iframe {
 	height: 400px;
 	height: 60vh;

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -90,8 +90,6 @@ h2.sidebar a:focus,h2.sidebar a:hover,h2.sidebar a:active{text-decoration:underl
 #mod-options li:not(:last-child){margin-block-end:0.25em}
 #mod-options a{padding-inline:.375em;display:block}
 #mod-options a span{padding-inline-start:16px}
-#mod-options a.report{background:url(images/bg_sprite_4.png) no-repeat .375em -45px}
-html[dir="rtl"] #mod-options a.report{background-position-x:calc(100% - .375em)}
 #mod-options a.delete-spam{background:url(images/bg_sprite_3.png) no-repeat .375em -45px}
 html[dir="rtl"] #mod-options a.delete-spam{background-position-x:calc(100% - .375em)}
 input[name=sort_of_agreement] + iframe {height:400px;height:60vh}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -90,8 +90,6 @@ h2.sidebar a:focus,h2.sidebar a:hover,h2.sidebar a:active{text-decoration:underl
 #mod-options li:not(:last-child){margin-block-end:0.25em}
 #mod-options a{padding-inline:.375em;display:block}
 #mod-options a span{padding-inline-start:16px}
-#mod-options a.delete-spam{background:url(images/bg_sprite_3.png) no-repeat .375em -45px}
-html[dir="rtl"] #mod-options a.delete-spam{background-position-x:calc(100% - .375em)}
 input[name=sort_of_agreement] + iframe {height:400px;height:60vh}
 #usersonline{background:#f9f9f9;border:1px solid #bacbdf;margin:20px 0}
 #usersonline h3{font-size:.69em;line-height:1.7em;font-weight:400;margin:0;padding:0 5px;background:#d2ddea; background:linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 100%)}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -90,8 +90,6 @@ h2.sidebar a:focus,h2.sidebar a:hover,h2.sidebar a:active{text-decoration:underl
 #mod-options li:not(:last-child){margin-block-end:0.25em}
 #mod-options a{padding-inline:.375em;display:block}
 #mod-options a span{padding-inline-start:16px}
-#mod-options a.manage{background:url(images/bg_sprite_4.png) no-repeat .375em -344px}
-html[dir="rtl"] #mod-options a.manage{background-position-x:calc(100% - .375em)}
 #mod-options a.report{background:url(images/bg_sprite_4.png) no-repeat .375em -45px}
 html[dir="rtl"] #mod-options a.report{background-position-x:calc(100% - .375em)}
 #mod-options a.delete-spam{background:url(images/bg_sprite_3.png) no-repeat .375em -45px}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -89,7 +89,6 @@ h2.sidebar a:focus,h2.sidebar a:hover,h2.sidebar a:active{text-decoration:underl
 #mod-options{list-style:none;margin:0;padding:0;font-size:.82em;line-height:1.7}
 #mod-options li:not(:last-child){margin-block-end:0.25em}
 #mod-options a{padding-inline:.375em;display:block}
-#mod-options a span{padding-inline-start:16px}
 input[name=sort_of_agreement] + iframe {height:400px;height:60vh}
 #usersonline{background:#f9f9f9;border:1px solid #bacbdf;margin:20px 0}
 #usersonline h3{font-size:.69em;line-height:1.7em;font-weight:400;margin:0;padding:0 5px;background:#d2ddea; background:linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 100%)}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -98,8 +98,6 @@ html[dir="rtl"] #mod-options a.manage{background-position-x:calc(100% - .375em)}
 html[dir="rtl"] #mod-options a.report{background-position-x:calc(100% - .375em)}
 #mod-options a.delete-spam{background:url(images/bg_sprite_3.png) no-repeat .375em -45px}
 html[dir="rtl"] #mod-options a.delete-spam{background-position-x:calc(100% - .375em)}
-#mod-options a.non-activated-users{background:url(images/bg_sprite_4.png) no-repeat .375em -393px}
-html[dir="rtl"] #mod-options a.non-activated-users{background-position-x:calc(100% - .375em)}
 input[name=sort_of_agreement] + iframe {height:400px;height:60vh}
 #usersonline{background:#f9f9f9;border:1px solid #bacbdf;margin:20px 0}
 #usersonline h3{font-size:.69em;line-height:1.7em;font-weight:400;margin:0;padding:0 5px;background:#d2ddea; background:linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 100%)}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -88,7 +88,7 @@ h2.sidebar a:focus,h2.sidebar a:hover,h2.sidebar a:active{text-decoration:underl
 #modmenu{background:#f9f9f9;border:1px solid #bacbdf}
 #mod-options{list-style:none;margin:0;padding:0;font-size:.82em;line-height:1.7}
 #mod-options li:not(:last-child){margin-block-end:0.25em}
-#mod-options a{padding-inline:.375em;display:block}
+#mod-options a{padding-inline:.375em}
 input[name=sort_of_agreement] + iframe {height:400px;height:60vh}
 #usersonline{background:#f9f9f9;border:1px solid #bacbdf;margin:20px 0}
 #usersonline h3{font-size:.69em;line-height:1.7em;font-weight:400;margin:0;padding:0 5px;background:#d2ddea; background:linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 100%)}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -90,8 +90,6 @@ h2.sidebar a:focus,h2.sidebar a:hover,h2.sidebar a:active{text-decoration:underl
 #mod-options li:not(:last-child){margin-block-end:0.25em}
 #mod-options a{padding-inline:.375em;display:block}
 #mod-options a span{padding-inline-start:16px}
-#mod-options a.delete-marked{background:url(images/bg_sprite_4.png) no-repeat .375em -293px}
-html[dir="rtl"] #mod-options a.delete-marked{background-position-x:calc(100% - .375em)}
 #mod-options a.manage{background:url(images/bg_sprite_4.png) no-repeat .375em -344px}
 html[dir="rtl"] #mod-options a.manage{background-position-x:calc(100% - .375em)}
 #mod-options a.report{background:url(images/bg_sprite_4.png) no-repeat .375em -45px}

--- a/themes/default/subtemplates/index.inc.tpl
+++ b/themes/default/subtemplates/index.inc.tpl
@@ -24,12 +24,12 @@
 <div id="modmenu">
 	<h3>{#options#}</h3>
 	<ul id="mod-options">
-		<li><a href="index.php?mode=posting&amp;delete_marked=true" class="delete-marked"><span>{#delete_marked_link#}</span></a></li>
 		<li><a href="index.php?mode=posting&amp;manage_postings=true" class="manage"><span>{#manage_postings_link#}</span></a></li>
 		{if $show_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.show_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $hide_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.hide_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $delete_spam_link}<li><a href="index.php?mode=posting&amp;delete_spam=true" class="delete-spam"><span>{#delete_spam_link#}</span></a></li>{/if}
 		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/user-add.svg" alt="" width="12" height="12"/><span>{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</span></a></li>{/if}
+		<li><a href="index.php?mode=posting&amp;delete_marked=true" class="delete-marked"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/marker-active.svg" alt="" width="12" height="12"/><span>{#delete_marked_link#}</span></a></li>
 	</ul>
 </div>
 {/if}

--- a/themes/default/subtemplates/index.inc.tpl
+++ b/themes/default/subtemplates/index.inc.tpl
@@ -24,12 +24,12 @@
 <div id="modmenu">
 	<h3>{#options#}</h3>
 	<ul id="mod-options">
-		<li><a href="index.php?mode=posting&amp;manage_postings=true" class="manage"><span>{#manage_postings_link#}</span></a></li>
 		{if $show_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.show_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $hide_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.hide_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $delete_spam_link}<li><a href="index.php?mode=posting&amp;delete_spam=true" class="delete-spam"><span>{#delete_spam_link#}</span></a></li>{/if}
 		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/user-add.svg" alt="" width="12" height="12"/><span>{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</span></a></li>{/if}
 		<li><a href="index.php?mode=posting&amp;delete_marked=true" class="delete-marked"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/marker-active.svg" alt="" width="12" height="12"/><span>{#delete_marked_link#}</span></a></li>
+		<li><a href="index.php?mode=posting&amp;manage_postings=true" class="manage"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/manage-marked-postings.svg" alt="" width="12" height="12"/><span>{#manage_postings_link#}</span></a></li>
 	</ul>
 </div>
 {/if}

--- a/themes/default/subtemplates/index.inc.tpl
+++ b/themes/default/subtemplates/index.inc.tpl
@@ -24,12 +24,12 @@
 <div id="modmenu">
 	<h3>{#options#}</h3>
 	<ul id="mod-options">
-		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users"><span>{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</span></a></li>{/if}
 		<li><a href="index.php?mode=posting&amp;delete_marked=true" class="delete-marked"><span>{#delete_marked_link#}</span></a></li>
 		<li><a href="index.php?mode=posting&amp;manage_postings=true" class="manage"><span>{#manage_postings_link#}</span></a></li>
 		{if $show_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.show_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $hide_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.hide_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $delete_spam_link}<li><a href="index.php?mode=posting&amp;delete_spam=true" class="delete-spam"><span>{#delete_spam_link#}</span></a></li>{/if}
+		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/user-add.svg" alt="" width="12" height="12"/><span>{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</span></a></li>{/if}
 	</ul>
 </div>
 {/if}

--- a/themes/default/subtemplates/index.inc.tpl
+++ b/themes/default/subtemplates/index.inc.tpl
@@ -24,12 +24,12 @@
 <div id="modmenu">
 	<h3>{#options#}</h3>
 	<ul id="mod-options">
-		{if $delete_spam_link}<li><a href="index.php?mode=posting&amp;delete_spam=true" class="delete-spam"><span>{#delete_spam_link#}</span></a></li>{/if}
 		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/user-add.svg" alt="" width="12" height="12"/><span>{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</span></a></li>{/if}
 		<li><a href="index.php?mode=posting&amp;delete_marked=true" class="delete-marked"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/marker-active.svg" alt="" width="12" height="12"/><span>{#delete_marked_link#}</span></a></li>
 		<li><a href="index.php?mode=posting&amp;manage_postings=true" class="manage"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/manage-marked-postings.svg" alt="" width="12" height="12"/><span>{#manage_postings_link#}</span></a></li>
 		{if $show_spam_link}<li><a href="index.php?show_spam=true" class="report"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/general-caution.svg" alt="" width="12" height="12"/><span>{$smarty.config.show_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $hide_spam_link}<li><a href="index.php?show_spam=true" class="report"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/general-caution.svg" alt="" width="12" height="12"/><span>{$smarty.config.hide_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
+		{if $delete_spam_link}<li><a href="index.php?mode=posting&amp;delete_spam=true" class="delete-spam"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/delete-cross.svg" alt="" width="12" height="12"/><span>{#delete_spam_link#}</span></a></li>{/if}
 	</ul>
 </div>
 {/if}

--- a/themes/default/subtemplates/index.inc.tpl
+++ b/themes/default/subtemplates/index.inc.tpl
@@ -24,12 +24,12 @@
 <div id="modmenu">
 	<h3>{#options#}</h3>
 	<ul id="mod-options">
-		{if $show_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.show_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
-		{if $hide_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.hide_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $delete_spam_link}<li><a href="index.php?mode=posting&amp;delete_spam=true" class="delete-spam"><span>{#delete_spam_link#}</span></a></li>{/if}
 		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/user-add.svg" alt="" width="12" height="12"/><span>{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</span></a></li>{/if}
 		<li><a href="index.php?mode=posting&amp;delete_marked=true" class="delete-marked"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/marker-active.svg" alt="" width="12" height="12"/><span>{#delete_marked_link#}</span></a></li>
 		<li><a href="index.php?mode=posting&amp;manage_postings=true" class="manage"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/manage-marked-postings.svg" alt="" width="12" height="12"/><span>{#manage_postings_link#}</span></a></li>
+		{if $show_spam_link}<li><a href="index.php?show_spam=true" class="report"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/general-caution.svg" alt="" width="12" height="12"/><span>{$smarty.config.show_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
+		{if $hide_spam_link}<li><a href="index.php?show_spam=true" class="report"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/general-caution.svg" alt="" width="12" height="12"/><span>{$smarty.config.hide_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 	</ul>
 </div>
 {/if}

--- a/themes/default/subtemplates/index_table.inc.tpl
+++ b/themes/default/subtemplates/index_table.inc.tpl
@@ -96,12 +96,12 @@
 <div id="modmenu">
 	<h3>{#options#}</h3>
 	<ul id="mod-options">
-		{if $show_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.show_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
-		{if $hide_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.hide_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $delete_spam_link}<li><a href="index.php?mode=posting&amp;delete_spam=true" class="delete-spam"><span>{#delete_spam_link#}</span></a></li>{/if}
 		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/user-add.svg" alt="" width="12" height="12"/><span>{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</span></a></li>{/if}
 		<li><a href="index.php?mode=posting&amp;delete_marked=true" class="delete-marked"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/marker-active.svg" alt="" width="12" height="12"/><span>{#delete_marked_link#}</span></a></li>
 		<li><a href="index.php?mode=posting&amp;manage_postings=true" class="manage"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/manage-marked-postings.svg" alt="" width="12" height="12"/><span>{#manage_postings_link#}</span></a></li>
+		{if $show_spam_link}<li><a href="index.php?show_spam=true" class="report"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/general-caution.svg" alt="" width="12" height="12"/><span>{$smarty.config.show_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
+		{if $hide_spam_link}<li><a href="index.php?show_spam=true" class="report"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/general-caution.svg" alt="" width="12" height="12"/><span>{$smarty.config.hide_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 	</ul>
 </div>{/if}
 </div>

--- a/themes/default/subtemplates/index_table.inc.tpl
+++ b/themes/default/subtemplates/index_table.inc.tpl
@@ -96,12 +96,12 @@
 <div id="modmenu">
 	<h3>{#options#}</h3>
 	<ul id="mod-options">
-		<li><a href="index.php?mode=posting&amp;delete_marked=true" class="delete-marked"><span>{#delete_marked_link#}</span></a></li>
 		<li><a href="index.php?mode=posting&amp;manage_postings=true" class="manage"><span>{#manage_postings_link#}</span></a></li>
 		{if $show_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.show_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $hide_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.hide_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $delete_spam_link}<li><a href="index.php?mode=posting&amp;delete_spam=true" class="delete-spam"><span>{#delete_spam_link#}</span></a></li>{/if}
 		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/user-add.svg" alt="" width="12" height="12"/><span>{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</span></a></li>{/if}
+		<li><a href="index.php?mode=posting&amp;delete_marked=true" class="delete-marked"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/marker-active.svg" alt="" width="12" height="12"/><span>{#delete_marked_link#}</span></a></li>
 	</ul>
 </div>{/if}
 </div>

--- a/themes/default/subtemplates/index_table.inc.tpl
+++ b/themes/default/subtemplates/index_table.inc.tpl
@@ -96,12 +96,12 @@
 <div id="modmenu">
 	<h3>{#options#}</h3>
 	<ul id="mod-options">
-		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users"><span>{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</span></a></li>{/if}
 		<li><a href="index.php?mode=posting&amp;delete_marked=true" class="delete-marked"><span>{#delete_marked_link#}</span></a></li>
 		<li><a href="index.php?mode=posting&amp;manage_postings=true" class="manage"><span>{#manage_postings_link#}</span></a></li>
 		{if $show_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.show_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $hide_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.hide_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $delete_spam_link}<li><a href="index.php?mode=posting&amp;delete_spam=true" class="delete-spam"><span>{#delete_spam_link#}</span></a></li>{/if}
+		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/user-add.svg" alt="" width="12" height="12"/><span>{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</span></a></li>{/if}
 	</ul>
 </div>{/if}
 </div>

--- a/themes/default/subtemplates/index_table.inc.tpl
+++ b/themes/default/subtemplates/index_table.inc.tpl
@@ -96,12 +96,12 @@
 <div id="modmenu">
 	<h3>{#options#}</h3>
 	<ul id="mod-options">
-		{if $delete_spam_link}<li><a href="index.php?mode=posting&amp;delete_spam=true" class="delete-spam"><span>{#delete_spam_link#}</span></a></li>{/if}
 		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/user-add.svg" alt="" width="12" height="12"/><span>{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</span></a></li>{/if}
 		<li><a href="index.php?mode=posting&amp;delete_marked=true" class="delete-marked"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/marker-active.svg" alt="" width="12" height="12"/><span>{#delete_marked_link#}</span></a></li>
 		<li><a href="index.php?mode=posting&amp;manage_postings=true" class="manage"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/manage-marked-postings.svg" alt="" width="12" height="12"/><span>{#manage_postings_link#}</span></a></li>
 		{if $show_spam_link}<li><a href="index.php?show_spam=true" class="report"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/general-caution.svg" alt="" width="12" height="12"/><span>{$smarty.config.show_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $hide_spam_link}<li><a href="index.php?show_spam=true" class="report"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/general-caution.svg" alt="" width="12" height="12"/><span>{$smarty.config.hide_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
+		{if $delete_spam_link}<li><a href="index.php?mode=posting&amp;delete_spam=true" class="delete-spam"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/delete-cross.svg" alt="" width="12" height="12"/><span>{#delete_spam_link#}</span></a></li>{/if}
 	</ul>
 </div>{/if}
 </div>

--- a/themes/default/subtemplates/index_table.inc.tpl
+++ b/themes/default/subtemplates/index_table.inc.tpl
@@ -96,12 +96,12 @@
 <div id="modmenu">
 	<h3>{#options#}</h3>
 	<ul id="mod-options">
-		<li><a href="index.php?mode=posting&amp;manage_postings=true" class="manage"><span>{#manage_postings_link#}</span></a></li>
 		{if $show_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.show_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $hide_spam_link}<li><a href="index.php?show_spam=true" class="report"><span>{$smarty.config.hide_spam_link|replace:"[number]":$total_spam}</span></a></li>{/if}
 		{if $delete_spam_link}<li><a href="index.php?mode=posting&amp;delete_spam=true" class="delete-spam"><span>{#delete_spam_link#}</span></a></li>{/if}
 		{if $number_of_non_activated_users}<li><a href="index.php?mode=user" class="non-activated-users"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/user-add.svg" alt="" width="12" height="12"/><span>{#non_activated_users_link#|replace:'[counter]':$number_of_non_activated_users}</span></a></li>{/if}
 		<li><a href="index.php?mode=posting&amp;delete_marked=true" class="delete-marked"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/marker-active.svg" alt="" width="12" height="12"/><span>{#delete_marked_link#}</span></a></li>
+		<li><a href="index.php?mode=posting&amp;manage_postings=true" class="manage"><img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/images/manage-marked-postings.svg" alt="" width="12" height="12"/><span>{#manage_postings_link#}</span></a></li>
 	</ul>
 </div>{/if}
 </div>


### PR DESCRIPTION
This pull request adds SVG icons to the moderation menu in the sidbars of the overview pages. It adds one new icon and reuses four other icons, that are already in use at other places. Because of the nested font size definitions the icons preliminary will be displayed in a small 12 pixel grid. This will change when the font size definitions will be reworked and thereby simplified.

This pull request is related to #808.