### PR TITLE
Further fixes for the SVG icons 

### DIFF
--- a/themes/default/images/thread-marker-no-change.svg
+++ b/themes/default/images/thread-marker-no-change.svg
@@ -2,7 +2,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="264" height="264" viewBox="0 0 264 264">
  <style type="text/css">
   <![CDATA[
-  svg { border: 1px solid #666; fill: transparent; }
+  svg { fill: transparent; }
   #container { fill: #fff; stroke-width: 20; stroke: #bbb; stroke-linejoin: round; }
   #lines { fill: none; stroke-width: 16; stroke: #222; stroke-linecap: round; }
   ]]>


### PR DESCRIPTION
This is a further collection of fixes in context of the change to SVG icons.

- Remove the border from the image thread-marker-no-change.svg, it's a remaining of the development stage