### PR TITLE
Display the posting buttons with the icons only

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -710,7 +710,7 @@ function DragAndDropTable(table,mode,queryKey) {
 		imageCanvas.onclick = function(e) {
 			imageCanvas.setVisible(false);
 			stopTrigger();
-		}; 
+		};
 		imageCanvas.setVisible(false);
 		var fullSizeImage = document.getElementById("fullSizeImage") || document.createElementWithAttributes("img", {"id": "fullSizeImage"}, imageCanvas);
 		for (var i=0; i<els.length; i++) {

--- a/js/posting.js
+++ b/js/posting.js
@@ -554,6 +554,9 @@ function ButtonGroup(f) {
 			b.appendChild(buttonIcon);
 		}
 		var buttonSpan = document.createElement("span");
+		if (!obj.isSmilie) {
+			buttonSpan.setAttribute("class", "sr-only");
+		}
 		if (typeof obj.label == "string")
 			buttonSpan.appendChild(document.createTextNode( obj.label ));
 		else

--- a/js/posting.js
+++ b/js/posting.js
@@ -474,6 +474,10 @@ function ButtonGroup(f) {
 	var convertInstructionsToButton = function() {
 		if (!document.getElementById("bbcode-bar"))
 			return;
+		const formattingBar = document.getElementById("format-bar");
+		if (formattingBar.hasAttribute("hidden")) {
+			formattingBar.removeAttribute("hidden");
+		}
 		var buttonBar = document.getElementById("bbcode-bar");
 		
 		if (document.getElementById("bbcode-instructions")) {

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -1204,7 +1204,7 @@ div#entry-input,
 div#format-bar {
 	margin: 0 !important;
 	padding: 0.375em;
-	background: #f2f2f2;
+	background: #f4f4f6;
 }
 #postingform #format-bar > * {
 	display: flex;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -1217,7 +1217,6 @@ div#format-bar {
 
 #format-bar button {
 	font-size: 0.82em;
-	min-height: 2.4em;
 	margin: 0;
 	padding-block: 0.675em;
 	padding-inline: 0.675em;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -1234,6 +1234,14 @@ div#format-bar {
 	background-color: #f4f4dc;
 	border-color: #f03434;
 }
+#format-bar button img,
+#additional-smilies button img {
+	display: block;
+	width: 1.375em;
+	height: auto;
+	margin: 0;
+	padding: 0;
+}
 #format-bar button span {
 	display: block;
 	line-height: 1.4em;
@@ -1324,14 +1332,6 @@ div#format-bar {
 	padding-inline: 1em;
 	background: transparent;
 	border: none;
-}
-#smiley-bar button img,
-#additional-smilies button img {
-	display: block;
-	width: 1.2em;
-	height: auto;
-	margin: 0;
-	padding: 0;
 }
 
 #formatting-help > * {

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -1209,7 +1209,7 @@ div#format-bar {
 #postingform #format-bar > * {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 0.125em;
+	gap: 0.25em;
 }
 #postingform #format-bar > *:not(:last-child) {
 	margin-block-end: 0.375em;
@@ -1219,8 +1219,21 @@ div#format-bar {
 	font-size: 0.82em;
 	min-height: 2.4em;
 	margin: 0;
-	padding-block: 0.25em;
-	padding-inline: 0.75em;
+	padding-block: 0.675em;
+	padding-inline: 0.675em;
+	background-color: #ececf2;
+	border: 1px solid #888;
+	border-radius: 0.25em;
+}
+#format-bar button:hover,
+#format-bar button:focus,
+#format-bar button:focus-within {
+	background-color: #f4f4fa;
+	border-color: #d01210;
+}
+#format-bar button:active {
+	background-color: #f4f4dc;
+	border-color: #f03434;
 }
 #format-bar button span {
 	display: block;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -2006,6 +2006,16 @@ img.right {
 	max-width: 90%;
 }
 
+/* class to make alements visually hiddeb but leave them accessible for screenreaders (.sr-only = screen readers only) */
+.sr-only:not(:focus):not(:active) {
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+}
 /* JS Classes */
 .js-display-none {
 	display: none;

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -243,7 +243,7 @@ div#entry-input,#postingform input[type="text"],#postingform input[type="email"]
 div#format-bar{margin:0 !important;padding:.375em;background:#f4f4f6}
 #postingform #format-bar > *{display:flex;flex-wrap:wrap;gap:.25em}
 #postingform #format-bar > *:not(:last-child){margin-block-end:.375em}
-#format-bar button{font-size:.82em;min-height:2.4em;margin:0;padding-block:.675em;padding-inline:.675em;background-color:#ececf2;border:1px solid #888;border-radius:.25em}
+#format-bar button{font-size:.82em;margin:0;padding-block:.675em;padding-inline:.675em;background-color:#ececf2;border:1px solid #888;border-radius:.25em}
 #format-bar button:hover,#format-bar button:focus,#format-bar button:focus-within{background-color:#f4f4fa;border-color:#d01210}
 #format-bar button:active{background-color:#f4f4dc;border-color:#f03434}
 #format-bar button span{display:block;line-height:1.4em}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -241,9 +241,11 @@ div#entry-input,#postingform input[type="text"],#postingform input[type="email"]
 #delete_cookie{font-size:.82em}
 #delete_cookie a{padding-left:13px;background:url(images/bg_sprite_3.png) no-repeat 0 -47px}
 div#format-bar{margin:0 !important;padding:.375em;background:#f2f2f2}
-#postingform #format-bar > *{display:flex;flex-wrap:wrap;gap:.125em}
+#postingform #format-bar > *{display:flex;flex-wrap:wrap;gap:.25em}
 #postingform #format-bar > *:not(:last-child){margin-block-end:.375em}
-#format-bar button{font-size:.82em;min-height:2.4em;margin:0;padding-block:.25em;padding-inline:.75em}
+#format-bar button{font-size:.82em;min-height:2.4em;margin:0;padding-block:.675em;padding-inline:.675em;background-color:#ececf2;border:1px solid #888;border-radius:.25em}
+#format-bar button:hover,#format-bar button:focus,#format-bar button:focus-within{background-color:#f4f4fa;border-color:#d01210}
+#format-bar button:active{background-color:#f4f4dc;border-color:#f03434}
 #format-bar button span{display:block;line-height:1.4em}
 #bbcodebutton-b span{font-weight:700}
 #bbcodebutton-i span{font-style:italic}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -240,7 +240,7 @@ div#entry-input,#postingform input[type="text"],#postingform input[type="email"]
 #postingform .small,#postingform .xsmall{font-size:.82em}
 #delete_cookie{font-size:.82em}
 #delete_cookie a{padding-left:13px;background:url(images/bg_sprite_3.png) no-repeat 0 -47px}
-div#format-bar{margin:0 !important;padding:.375em;background:#f2f2f2}
+div#format-bar{margin:0 !important;padding:.375em;background:#f4f4f6}
 #postingform #format-bar > *{display:flex;flex-wrap:wrap;gap:.25em}
 #postingform #format-bar > *:not(:last-child){margin-block-end:.375em}
 #format-bar button{font-size:.82em;min-height:2.4em;margin:0;padding-block:.675em;padding-inline:.675em;background-color:#ececf2;border:1px solid #888;border-radius:.25em}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -398,6 +398,7 @@ img.right{float:right;float:inline-end;margin:0 0 10px 10px}
 #ajax-preview-content img{max-width:100%;height:auto}
 #image-canvas{position:absolute;top:0;left:0;width:100%;height:100%;background:url(images/canvas_bg.png);z-index:20}
 #image-canvas img{display:block;margin:2em auto 0;border:1px solid #000;z-index:30;max-width:90%}
+.sr-only:not(:focus):not(:active){clip:rect(0 0 0 0);clip-path:inset(50%);width:1px;height:1px;overflow:hidden;position:absolute;white-space:nowrap}
 .js-display-none{display:none}
 .js-display-block{display:block}
 .js-visibility-hidden{visibility:hidden}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -246,6 +246,7 @@ div#format-bar{margin:0 !important;padding:.375em;background:#f4f4f6}
 #format-bar button{font-size:.82em;margin:0;padding-block:.675em;padding-inline:.675em;background-color:#ececf2;border:1px solid #888;border-radius:.25em}
 #format-bar button:hover,#format-bar button:focus,#format-bar button:focus-within{background-color:#f4f4fa;border-color:#d01210}
 #format-bar button:active{background-color:#f4f4dc;border-color:#f03434}
+#format-bar button img,#additional-smilies button img{display:block;width:1.375em;height:auto;margin:0;padding:0}
 #format-bar button span{display:block;line-height:1.4em}
 #bbcodebutton-b span{font-weight:700}
 #bbcodebutton-i span{font-style:italic}
@@ -263,7 +264,6 @@ div#format-bar{margin:0 !important;padding:.375em;background:#f4f4f6}
 #bbcode-options table a:focus,#bbcode-options table a:hover{border:1px solid #fff;text-decoration:none}
 #additional-smilies{max-width:200px;display:flex;flex-wrap:wrap;align-items:self-start;align-content:stretch;gap:.125em}
 #additional-smilies button{font-size:.82em;min-height:2.4em;margin:0;padding-block:.25em;padding-inline:1em;background:transparent;border:none}
-#smiley-bar button img,#additional-smilies button img{display:block;width:1.2em;height:auto;margin:0;padding:0}
 #formatting-help > *{margin-block:0 .75em;margin-block:0 .75rem;padding:0}
 #formatting-help dl > div:not(:last-child){margin-block:0 .375em}
 #formatting-help dt{font-weight:bold}

--- a/themes/default/subtemplates/posting.inc.tpl
+++ b/themes/default/subtemplates/posting.inc.tpl
@@ -246,7 +246,7 @@ JavaScript isn't available.
 
    <div>
 
-    <div id="format-bar">
+    <div id="format-bar" hidden>
 {if $settings.bbcode}
      <div id="bbcode-bar">
 {*<!--


### PR DESCRIPTION
As discussed [in the project forum](https://mylittleforum.net/forum/index.php?id=19006) (ff., German language) it is in several forum and board systems common to show the formatting buttons of postings with icons only and without text.

With this pull request we are implementing this too. Beside hiding the text, which remains accessible for screen reader users, the appearance of the posting formatting buttons is now controlled with CSS and no longer left to the operating systems. Beside this the `div#format-bar` is from now on hidden and will only be displayed if the JavaScript function to generate the buttons is working. Until then the box was shown with not working JavaScript with the  height of one text line.