### PR TITLE
Initialising an array with value false is deprecated

### DIFF
--- a/includes/bookmark.inc.php
+++ b/includes/bookmark.inc.php
@@ -63,7 +63,7 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id'])) {
 			if (empty($row['user_name']))
 				$row['user_name'] = $lang['unknown_user'];
 			
-			while ($row = mysqli_fetch_array($bookmark_result)) {
+			while ($row = mysqli_fetch_assoc($bookmark_result)) {
 				$tag = $row['tag'];
 				$tags_array = false;
 				if (!is_null($tag)) {

--- a/includes/bookmark.inc.php
+++ b/includes/bookmark.inc.php
@@ -58,7 +58,7 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id'])) {
 				ORDER BY ".$db_settings['bookmark_table'].".`order_id` ASC") or raise_error('database_error',mysqli_error($connid));
 
 			$total_bookmarks = mysqli_num_rows($bookmark_result);
-			$bookmarkdata = false;
+			$bookmarkdata = [];
 			
 			if (empty($row['user_name']))
 				$row['user_name'] = $lang['unknown_user'];
@@ -90,7 +90,7 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id'])) {
 			}
 
 			mysqli_free_result($bookmark_result);
-			if ($bookmarkdata)
+			if (!empty($bookmarkdata))
 				$smarty->assign('bookmarkdata',$bookmarkdata);
 
 			$breadcrumbs[0]['link'] = 'index.php?mode=bookmarks';


### PR DESCRIPTION
Because of this the variable gets initialised as an empty array. Because of this change the check for existing content of the variable checks for `!empty()` from now on.