### PR TITLE
No null value for array $last_posting

### DIFF
--- a/includes/user.inc.php
+++ b/includes/user.inc.php
@@ -216,11 +216,12 @@ if ($isUser || $hasUserAreaAccess) {
 				if ($days_registered < 1) $days_registered = 1;
 				$smarty->assign('logins_per_day', number_format($row['logins'] / $days_registered, 2));
 				$smarty->assign('postings_per_day', number_format($postings / $days_registered, 2));
-				$smarty->assign('last_posting_id', intval($last_posting['id']));
-				$smarty->assign('last_posting_formated_time', htmlspecialchars(format_time($lang['time_format_full'], $last_posting['disp_time'])));
-				$smarty->assign('last_posting_time', $last_posting['disp_time']);
-				$smarty->assign('last_posting_subject', htmlspecialchars($last_posting['subject']));
-
+				if ($last_posting !== null) {
+					$smarty->assign('last_posting_id', intval($last_posting['id']));
+					$smarty->assign('last_posting_formated_time', htmlspecialchars(format_time($lang['time_format_full'], $last_posting['disp_time'])));
+					$smarty->assign('last_posting_time', $last_posting['disp_time']);
+					$smarty->assign('last_posting_subject', htmlspecialchars($last_posting['subject']));
+				}
 				if ($settings['avatars']>0) {
 					$avatarInfo = getAvatar($id);
 					$avatar['image'] = $avatarInfo === false ? false : $avatarInfo[2];

--- a/includes/user.inc.php
+++ b/includes/user.inc.php
@@ -174,7 +174,10 @@ if ($isUser || $hasUserAreaAccess) {
 				// last posting:
 				if ($categories == false) $result = mysqli_query($connid, "SELECT id, subject, UNIX_TIMESTAMP(time + INTERVAL ".$time_difference." MINUTE) AS disp_time FROM ".$db_settings['forum_table']." WHERE user_id = ". intval($id) ." ORDER BY time DESC LIMIT 1") or raise_error('database_error', mysqli_error($connid));
 				else $result = mysqli_query($connid, "SELECT id, subject, UNIX_TIMESTAMP(time + INTERVAL ".$time_difference." MINUTE) AS disp_time FROM ".$db_settings['forum_table']." WHERE user_id = ". intval($id) ." AND category IN (". $category_ids_query .") ORDER BY time DESC LIMIT 1") or raise_error('database_error', mysqli_error($connid));
-				$last_posting = mysqli_fetch_array($result);
+				$last_posting = null;
+				if (mysqli_num_rows($result) > 0) {
+					$last_posting = mysqli_fetch_assoc($result);
+				}
 				mysqli_free_result($result);
 
 				$year = my_substr($row['birthday'], 0, 4, $lang['charset']);


### PR DESCRIPTION
Providing `NULL` values to functions `intval` and `htmlspecialchars` is reported as deprecated with PHP 8.1. Initialising the variable `$last_posting` in `includes/user.inc.php` with `NULL`, filling in the result of the previous database request only if the result has one content line and checking the variable for its content to decide if to process it for the template engine or not.