### PR TITLE
Forum upgrade script: separate the list of files to delete from the list of files to update

### DIFF
--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -518,7 +518,7 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 								}
 								$i++;
 							}
-							$smarty->assign('update_items', $items);
+							$smarty->assign('upload_items', $items);
 						}
 						if (isset($update['delete'])) {
 							$i = 0;

--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -520,6 +520,20 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 							}
 							$smarty->assign('update_items', $items);
 						}
+						if (isset($update['delete'])) {
+							$i = 0;
+							foreach ($update['delete'] as $item) {
+								if (my_substr($item, -1, 1, $lang['charset']) == '/') {
+									$items[$i]['type'] = 0;
+									$items[$i]['name'] = my_substr($item, 0, -1, $lang['charset']);
+								} else {
+									$items[$i]['type'] = 1;
+									$items[$i]['name'] = $item;
+								}
+								$i++;
+							}
+							$smarty->assign('delete_items', $items);
+						}
 						if (isset($update['download_url'])) $smarty->assign('update_download_url', $update['download_url']);
 						if (isset($update['message'])) $smarty->assign('update_message', $update['message']);
 						if (isset($update['new_version'])) $smarty->assign('update_new_version', $update['new_version']);

--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -508,6 +508,7 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 					else {
 						if (isset($update['items'])) {
 							$i = 0;
+							$items = [];
 							foreach ($update['items'] as $item) {
 								if (my_substr($item, -1, 1, $lang['charset']) == '/') {
 									$items[$i]['type'] = 0;
@@ -522,6 +523,7 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 						}
 						if (isset($update['delete'])) {
 							$i = 0;
+							$items = [];
 							foreach ($update['delete'] as $item) {
 								if (my_substr($item, -1, 1, $lang['charset']) == '/') {
 									$items[$i]['type'] = 0;

--- a/lang/arabic.lang
+++ b/lang/arabic.lang
@@ -1069,6 +1069,7 @@ update_confirm =                  'هل تريد حقًا تشغيل ملف ال
 update_submit =                   'حسنًا - تشغيل التحديث'
 update_successful =               'تم تحديث قاعدة البيانات بنجاح.'
 update_items_note =               ' (version [version]) ×:يرجى الآن تحميل الملفات/المجلدات التالية من حزمة المنتدى الجديدة (الإصدار) إلى الخادم الخاص بك'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =                 ' [[here]]×إذا لم يكن لديك هذه الملفات بعد، يمكنك تنزيلها.'
 update_reenabling_notice =        '<!-- TODO -->Please be aware, that the forum is currently deactivated and you must reenable it in <a href="index.php?mode=admin&action=settings">the settings</a>.'
 

--- a/lang/chinese.lang
+++ b/lang/chinese.lang
@@ -1070,6 +1070,7 @@ update_confirm =                  '是否确定要执行更新档？'
 update_submit =                   '执行更新'
 update_successful =               '数据库已更新成功。'
 update_items_note =               '请立即上传以下新压缩档内的文件和目录 (版本为 [version]) 到您的服务器中：'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =                 '若您还没有这些文件，可以从 [[here]] 下载。'
 update_reenabling_notice =        '<!--TODO-->Please be aware, that the forum is currently deactivated and you must reenable it in <a href="index.php?mode=admin&action=settings">the settings</a>.'
 

--- a/lang/chinese_traditional.lang
+++ b/lang/chinese_traditional.lang
@@ -1070,6 +1070,7 @@ update_confirm =                  '是否確定要執行更新檔？'
 update_submit =                   '執行更新'
 update_successful =               '資料庫已更新成功。'
 update_items_note =               '請立即上傳以下新壓縮檔內的檔案和資料夾 (版本為 [version]) 到您的伺服器中：'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =                 '若您還沒有這些檔案，可以從 [[here]] 下載。'
 update_reenabling_notice =        '<!--TODO-->Please be aware, that the forum is currently deactivated and you must reenable it in <a href="index.php?mode=admin&action=settings">the settings</a>.'
 

--- a/lang/croatian.lang
+++ b/lang/croatian.lang
@@ -1072,6 +1072,7 @@ update_confirm =                'Želite li zaista pokrenuti ovu instalacijsku d
 update_submit =                 'Pokreni instalaciju'
 update_successful =             'Baza je uspješno ažurirana.'
 update_items_note =             'Molimo vas da sada pošaljete sljedeće datoteke/direktorije iz arhive foruma (verzija [version]) na vaš poslužitelj:'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =               'Ako nemate potrebne datoteke možete ih naći ovdje: [[here]].'
 update_reenabling_notice =        '<!--TODO-->Please be aware, that the forum is currently deactivated and you must reenable it in <a href="index.php?mode=admin&action=settings">the settings</a>.'
 

--- a/lang/danish.lang
+++ b/lang/danish.lang
@@ -1072,6 +1072,7 @@ update_confirm =            'ønsker du virkelig at køre den følgende opdateri
 update_submit =             'OK - Kør opdatering'
 update_successful =         'Databasen blev opdateret uden fejl.'
 update_items_note =         'Upload nu venligst de følgende filer/mapper fra den nye forum pakke (version [version]) på din server:'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =           'Hvis du endnu ikke har disse filer kan du downloade dem [[her]].'
 update_reenabling_notice =        '<!--TODO-->Please be aware, that the forum is currently deactivated and you must reenable it in <a href="index.php?mode=admin&action=settings">the settings</a>.'
 

--- a/lang/english.lang
+++ b/lang/english.lang
@@ -1069,6 +1069,7 @@ update_confirm =                  'Do you really want to run the following updat
 update_submit =                   'OK - Run update'
 update_successful =               'The database has been updated successfully.'
 update_items_note =               'Please upload now the following files/folders of the new forum package (version [version]) to your server:'
+update_delete_note =              'Please remove now the following files/folders from your installation:'
 update_download =                 'If you do not have these files yet you can download them [[here]].'
 update_reenabling_notice =        'Please be aware, that the forum is currently deactivated and you must reenable it in <a href="index.php?mode=admin&action=settings">the settings</a>.'
 

--- a/lang/french.lang
+++ b/lang/french.lang
@@ -1076,6 +1076,7 @@ update_confirm =                  'Voulez-vous vraiement exécuter ce fichier de
 update_submit =                   'OK - Exécuter la mise à jour'
 update_successful =               'La base de données a été mise à jour avec succès.'
 update_items_note =               'Veuiller télécharger maintenant les fichiers ou les dossiers suivants de la nouvelle version de forum (version [version]) sur votre serveur :'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =                 'Si vous n\'avez pas ces fichiers vous pouvez les télécharger [[ici]].'
 update_reenabling_notice =        'Veuillez noter que le forum est actuellement désactivé et que vous devez le réactiver dans <a href="index.php?mode=admin&action=settings">les paramètres</a>.'
 

--- a/lang/german.lang
+++ b/lang/german.lang
@@ -1074,6 +1074,7 @@ update_confirm =                  'Sicher, dass diese Update-Datei ausgeführt w
 update_submit =                   'OK – Update ausführen'
 update_successful =               'Die Datenbank wurde erfolgreich aktualisiert.'
 update_items_note =               'Bitte jetzt die folgenden Dateien/Verzeichnisse der neuen Version ([version]) hochladen:'
+update_delete_note =              'Bitte jetzt die folgenden veralteten Dateien/Verzeichnisse aus der Installation löschen:'
 update_download =                 'Falls nicht verfügbar, können diese Dateien [[hier]] heruntergeladen werden.'
 update_reenabling_notice =        'Bitte zu beachten, dass das Forum aktuell deaktiviert ist und <a href="index.php?mode=admin&action=settings">in den Einstellungen</a> wieder eingeschaltet werden muss.'
 

--- a/lang/italian.lang
+++ b/lang/italian.lang
@@ -1073,6 +1073,7 @@ update_confirm =                  'Confermi l\'aggiornamento di con questo file?
 update_submit =                   'OK - ESEGUI AGGIORNAMENTO'
 update_successful =               'La base dati è stata aggiornata con successo.'
 update_items_note =               'Si prega di aggiornare ora i files/cartelle del nuovo forum (versione [version]) sul tuo server:'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =                 'Se non possiedi questi files, puoi scaricarti [[qui]].'
 update_reenabling_notice =        '<!--TODO-->Please be aware, that the forum is currently deactivated and you must reenable it in <a href="index.php?mode=admin&action=settings">the settings</a>.'
 

--- a/lang/norwegian.lang
+++ b/lang/norwegian.lang
@@ -1073,6 +1073,7 @@ update_confirm =                  'Vil du virkelig kjøre følgende oppdaterings
 update_submit =                   'OK - Kjør oppdatering'
 update_successful =               'Databasen ble oppdatert.'
 update_items_note =               'Last opp følgende filer fra den nye forumpakken (version [version]) til serveren din:'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =                 'Dersom du ikke har disse filene kan de lastes ned [[her]].'
 update_reenabling_notice =        '<!--TODO-->Please be aware, that the forum is currently deactivated and you must reenable it in <a href="index.php?mode=admin&action=settings">the settings</a>.'
 

--- a/lang/russian.lang
+++ b/lang/russian.lang
@@ -1085,6 +1085,7 @@ update_confirm =                  'Вы уверены, что хотите вы
 update_submit =                   'Выполнить'
 update_successful =               'База данных была успешно обновлена.'
 update_items_note =               'Теперь загрузите на ваш сервер следующие файлы и папки из нового пакета обновления форума (версии [version]):'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =                 'Если у вас ещё нет этих файлов, вы можете загрузить [[отсюда]].'
 update_reenabling_notice =        'Пожалуйста, обратите внимание, что форум в настоящее время отключен, и вы должны снова включить его в <a href="index.php?mode=admin&action=settings">настройках</a>.'
 

--- a/lang/spanish.lang
+++ b/lang/spanish.lang
@@ -1074,6 +1074,7 @@ update_confirm =                  '¿Seguro que quieres ejecutar esta actualizac
 update_submit =                   'OK - Actualizar'
 update_successful =               'La base de datos se ha actualizado correctamente.'
 update_items_note =               'Por favor, sube los siguientes archivos o carpetas de la nueva versión ([version]) a tu servidor:'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =                 'Si no tienes estos archivos puedes descargarlos [[here]].'
 update_reenabling_notice =        '<!--TODO-->Please be aware, that the forum is currently deactivated and you must reenable it in <a href="index.php?mode=admin&action=settings">the settings</a>.'
 

--- a/lang/swedish.lang
+++ b/lang/swedish.lang
@@ -1073,6 +1073,7 @@ update_confirm =                  'Vill Du verkligen installera följande uppdat
 update_submit =                   'OK - Uppdatera'
 update_successful =               'Databasen har uppdaterats.'
 update_items_note =               'Ladda upp följande filer/mappar från den hämtade uppdaterineg (version [version]) till servern:'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =                 'Om Du inte laddat ner filerna kan Du göra det här: [[here]].'
 update_reenabling_notice =        '<!--TODO-->Please be aware, that the forum is currently deactivated and you must reenable it in <a href="index.php?mode=admin&action=settings">the settings</a>.'
 

--- a/lang/tamil.lang
+++ b/lang/tamil.lang
@@ -1069,6 +1069,7 @@ update_confirm =                  'இந்த புதுப்பிப்�
 update_submit =                   'சரி - புதுப்பிக்கவும்'
 update_successful =               'டேடாபேஸ் புதுப்பிக்கமுடியவில்லை.'
 update_items_note =               'தயவு செய்து இந்த புதிய பொது மன்றத்தின் (பதிப்பு [version]) உறை / கோப்பை உங்கள் சேவை மைய்யத்திற்கு  நகற்த்துக :'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =                 'நீங்கள் இன்னும் இந்த கோப்புகளை பொறவில்லையேல் அநுகவும் [[here]] .'
 update_reenabling_notice =        '<!--TODO-->Please be aware, that the forum is currently deactivated and you must reenable it in <a href="index.php?mode=admin&action=settings">the settings</a>.'
 

--- a/lang/turkish.lang
+++ b/lang/turkish.lang
@@ -1073,6 +1073,7 @@ update_confirm =                  'Aşağıdaki güncellemeyi çalıştırmak is
 update_submit =                   'Tamam - Güncelle'
 update_successful =               'Veritabanı başarıyla güncelleştirildi.'
 update_items_note =               'Lütfen şimdi yeni forum paketinin (version [version]) şu dosyalarını/klasörlerini sunucunuza yükleyin:'
+update_delete_note =              '<!-- TODO -->Please remove now the following files/folders from your installation:'
 update_download =                 'Eğer henüz bu dosyalara sahip değilseniz [[buradan]] yükleyebilirsiniz.'
 update_reenabling_notice =        '<!--TODO-->Please be aware, that the forum is currently deactivated and you must reenable it in <a href="index.php?mode=admin&action=settings">the settings</a>.'
 

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -936,6 +936,14 @@
 {/foreach}
 </ul>
 {/if}
+{if $delete_items}
+<p>{#update_delete_note#}</p>
+<ul class="filelist">
+{foreach from=$delete_items item=item}
+<li><img class="icon" src="{$THEMES_DIR}/{$theme}/images/{if $item.type==0}dir-open.svg{else}file.svg{/if}" alt="[{if $item.type==0}{#folder_alt#}{else}{#file_alt#}{/if}]" width="16" height="16" />{$item.name}</li>
+{/foreach}
+</ul>
+{/if}
 <p>{#update_reenabling_notice#}</p>
 {if $update_download_url}<p class="small">{#update_download#|replace:"[[":"<a href=\"$update_download_url\">"|replace:"]]":"</a>"}</p>{/if}
 {if $update_message}{$update_message}{/if}

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -936,6 +936,14 @@
 {/foreach}
 </ul>
 {/if}
+{if $upload_items}
+<p>{#update_items_note#|replace:"[version]":$update_new_version}</p>
+<ul class="filelist">
+{foreach from=$upload_items item=item}
+<li><img class="icon" src="{$THEMES_DIR}/{$theme}/images/{if $item.type==0}dir-open.svg{else}file.svg{/if}" alt="[{if $item.type==0}{#folder_alt#}{else}{#file_alt#}{/if}]" width="16" height="16" />{$item.name}</li>
+{/foreach}
+</ul>
+{/if}
 {if $delete_items}
 <p>{#update_delete_note#}</p>
 <ul class="filelist">

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -928,14 +928,6 @@
 {else}
 <p class="notice ok">{#update_successful#}</p>
 {/if}
-{if $update_items}
-<p>{#update_items_note#|replace:"[version]":$update_new_version}</p>
-<ul class="filelist">
-{foreach from=$update_items item=item}
-<li><img class="icon" src="{$THEMES_DIR}/{$theme}/images/{if $item.type==0}dir-open.svg{else}file.svg{/if}" alt="[{if $item.type==0}{#folder_alt#}{else}{#file_alt#}{/if}]" width="16" height="16" />{$item.name}</li>
-{/foreach}
-</ul>
-{/if}
 {if $upload_items}
 <p>{#update_items_note#|replace:"[version]":$update_new_version}</p>
 <ul class="filelist">

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -4332,5 +4332,6 @@ if (empty($update['errors']) && in_array($settings['version'], array('20250422.1
 		$update['items'][] = 'js/posting.js';
 		$update['items'][] = 'js/posting.min.js';
 
+		$update['items'] = array_merge(reorderUpgradeFiles($update['items']), reorderUpgradeFiles($update['delete']));
 	}
 }

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -4287,7 +4287,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('20250323.1
 	}
 }
 
-if (empty($update['errors']) && in_array($settings['version'], array('20259999.1'))) {
+if (empty($update['errors']) && in_array($settings['version'], array('20250422.1'))) {
 	/**
 	 * From here on everything can be done as a transaction in one step
 	 */


### PR DESCRIPTION
Until now one gets displayed a list of files to upload and within this list items with files to delete in the second step of a forum upgrade. While *a few* obsolete images, templates or JavaScript files which remains in an installation, it is no good style to have obsolete server scripts or *masses* of obsolete images on the server.

In the light of replacing almost all pixel grid images of the default theme with SVG images there are really *many* image files to be deleted. All these entries would land in the single list and would blow up the list with that many files to delete. In the list of files that need to be uploaded ***and*** files that need to be deleted, there is a risk that individual items will be overlooked. On the one hand, entries may be forgotten, and on the other hand, entries may be misinterpreted. Files that need to be uploaded could be deleted and vice versa. 

Because of this risk I separated the list of files to delete from the list of files to (re)-upload. The list of files to delete will be displayed below the list of files to (re)-upload.