### PR TITLE
Fix the bold font formatting for the links and breadcrumbs in the subnavigation bar and for the reply link 

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -168,15 +168,15 @@ body > * {
 	margin: 0;
 	padding: 0;
 }
+#subnav-1 * {
+	margin: 0;
+	padding: 0;
+	font-weight: bold;
+}
 #subnav-2 {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 0 0.5em;
-}
-#subnav p.subnav {
-	margin: 0;
-	padding: 0;
-	font-weight: bold;
 }
 #subnav .small {
 	font-size: 0.82em;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -560,7 +560,6 @@ blockquote code {
 	font-weight: bold;
 }
 .posting-footer .locked {
-	font-size: 0.82em;
 	color: #808080;
 }
 .posting-footer .views {

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -171,6 +171,7 @@ body > * {
 #subnav-1 * {
 	margin: 0;
 	padding: 0;
+	text-wrap: nowrap;
 	font-weight: bold;
 }
 #subnav-2 {

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -163,6 +163,7 @@ body > * {
 	line-height: 2;
 	display: flex;
 	flex-direction: column;
+	gap: 0.125em 0.5em;
 }
 #subnav > * {
 	margin: 0;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -556,6 +556,9 @@ blockquote code {
 	font-size: 0.82em;
 	grid-area: replylink;
 }
+.posting-footer .reply a {
+	font-weight: bold;
+}
 .posting-footer .locked {
 	font-size: 0.82em;
 	color: #808080;

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -105,6 +105,7 @@ blockquote code{font-family:"courier new",courier;color:#6f6f6f}
 .posting-footer{margin:1em 0 0;padding:0;display:grid;grid-template-columns:1fr;grid-template-rows:auto auto auto;grid-template-areas:"pageviews" "replylink" "moderationlinks";gap:.25em}
 .posting-footer .reply{font-size:.82em;grid-area:replylink}
 .posting-footer .locked{font-size:.82em;color:gray}
+.posting-footer .reply a{font-weight:bold}
 .posting-footer .views{font-size:.69em;color:gray;text-align:end;grid-area:pageviews}
 #content .posting-footer .options{font-size:.69em!important;list-style-type:none;max-width:100%;margin:0;padding:0;grid-area:moderationlinks;display:flex;flex-wrap:wrap;gap:.5em;justify-content:flex-start}
 .posting-footer .options li{margin:0}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -28,7 +28,7 @@ body > *{margin:0;padding:0 1em;padding:0 1rem}
 #usermenu li a{white-space:nowrap}
 #topsearch div{display:inline;font-size:.82em}
 #topsearch #search-input{width:14em}
-#subnav{background:#f9f9f9;border-top:1px solid #bacbdf;border-bottom:1px solid #bacbdf;font-size:.82em;line-height:2;display:flex;flex-direction:column}
+#subnav{background:#f9f9f9;border-top:1px solid #bacbdf;border-bottom:1px solid #bacbdf;font-size:.82em;line-height:2;display:flex;flex-direction:column;gap:.125em .5em}
 #subnav > *{margin:0;padding:0}
 #subnav-1 *{margin:0;padding:0;text-wrap:nowrap;font-weight:bold}
 #subnav-2 {display:flex;flex-wrap:wrap;gap:0 .5em}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -104,8 +104,8 @@ html[dir="rtl"] blockquote{background-position-x:right}
 blockquote code{font-family:"courier new",courier;color:#6f6f6f}
 .posting-footer{margin:1em 0 0;padding:0;display:grid;grid-template-columns:1fr;grid-template-rows:auto auto auto;grid-template-areas:"pageviews" "replylink" "moderationlinks";gap:.25em}
 .posting-footer .reply{font-size:.82em;grid-area:replylink}
-.posting-footer .locked{font-size:.82em;color:gray}
 .posting-footer .reply a{font-weight:bold}
+.posting-footer .locked{color:gray}
 .posting-footer .views{font-size:.69em;color:gray;text-align:end;grid-area:pageviews}
 #content .posting-footer .options{font-size:.69em!important;list-style-type:none;max-width:100%;margin:0;padding:0;grid-area:moderationlinks;display:flex;flex-wrap:wrap;gap:.5em;justify-content:flex-start}
 .posting-footer .options li{margin:0}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -30,7 +30,7 @@ body > *{margin:0;padding:0 1em;padding:0 1rem}
 #topsearch #search-input{width:14em}
 #subnav{background:#f9f9f9;border-top:1px solid #bacbdf;border-bottom:1px solid #bacbdf;font-size:.82em;line-height:2;display:flex;flex-direction:column}
 #subnav > *{margin:0;padding:0}
-#subnav-1 *{margin:0;padding:0;font-weight:bold}
+#subnav-1 *{margin:0;padding:0;text-wrap:nowrap;font-weight:bold}
 #subnav-2 {display:flex;flex-wrap:wrap;gap:0 .5em}
 #subnav .small{font-size:.82em}
 #subnav form{display:inline}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -30,8 +30,8 @@ body > *{margin:0;padding:0 1em;padding:0 1rem}
 #topsearch #search-input{width:14em}
 #subnav{background:#f9f9f9;border-top:1px solid #bacbdf;border-bottom:1px solid #bacbdf;font-size:.82em;line-height:2;display:flex;flex-direction:column}
 #subnav > *{margin:0;padding:0}
+#subnav-1 *{margin:0;padding:0;font-weight:bold}
 #subnav-2 {display:flex;flex-wrap:wrap;gap:0 .5em}
-#subnav p.subnav{margin:0;padding:0;font-weight:bold}
 #subnav .small{font-size:.82em}
 #subnav form{display:inline}
 #subnav form div{display:inline}


### PR DESCRIPTION
During the work on implementing the new SVG icons and setting them into the HTML source code I removed the class `.stronglink` and its formatting for links that should be admirable on a page. This affected the links to the posting form in the footer of a posting and also the non-breadcrumb-links in `#subnav-1` in the subnavigation bar. I reformatted them without the removed class by selecting the links under a posting as link in the div of class `reply` (selector `.posting-footer .reply a`) respectively by making all childs of `#subnav-1` bold (selector `#subnav-1 *`).