### PR TITLE
Bold subject texts only in opening or the currently displayed postings

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -1638,6 +1638,9 @@ span.subject,
 a.subject,
 a.subject:link {
 	text-decoration: none;
+}
+ul.thread > li > .entry a.subject,
+span.subject {
 	font-weight: bold;
 }
 a.subject,

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -322,7 +322,8 @@ ul#uploadlist{list-style:none;margin-inline:0;margin-block:0 .75em;padding:0;max
 .confirm-selection li{min-height:2.5em;margin:0 0 .25em 0;padding:.25em .5em;border-bottom:1px solid #bacbdf}
 .confirm-selection .item{margin:0 0 .25em 0}
 .confirm-selection .info{font-weight:bold;margin:0}
-span.subject,a.subject,a.subject:link{text-decoration:none;font-weight:bold}
+span.subject,a.subject,a.subject:link{text-decoration:none;}
+ul.thread > li > .entry a.subject,span.subject{font-weight:bold}
 a.subject,a.subject:link{color:#00c}
 a.subject:visited{color:#007}
 a.subject:focus,a.subject:hover{color:#00f;text-decoration:underline}


### PR DESCRIPTION
Because of misreading the old code I removed the properties to make the text of subject lines of opening postings and currently displayed postings bold. With this PR this will be fixed.

Meanwhile the old code made all subject lines being bold in a first step and overwrote this for the subjects of replies in a second step (this was what was possible two decades ago) the new code selects only the wanted elements, namely the opening postings and the currently displayed posting in the thread tree in the single posting view.  