### PR TITLE
Further fixes for the new SVG icons

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -1677,9 +1677,6 @@ a.read:active {
 	color: #f00;
 }
 
-html[dir="rtl"] ul.thread img.icon.wd-dependent {
-	transform: scale(-1,1);
-}
 ul.thread li .entry > a,
 ul.thread li .current,
 ul.thread li .entry > .metadata {

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -332,7 +332,6 @@ a.subject:active{color:red}
 a.read,a.read:link,a.read:visited,#latest-postings li a span.read{color:#007}
 a.read:focus,a.read:hover{color:#00f}
 a.read:active{color:red}
-html[dir="rtl"] ul.thread img.icon.wd-dependent{transform:scale(-1,1)}
 ul.thread li .entry > a, ul.thread li .current, ul.thread li .entry > .metadata{text-wrap:nowrap}
 main:not(:has(table#threadlist)) ul.thread li .entry > a::after{content:" - "}
 .current{color:#ff0000}

--- a/themes/default/subtemplates/entry.inc.tpl
+++ b/themes/default/subtemplates/entry.inc.tpl
@@ -107,7 +107,7 @@
 {else}{$iconSrc="images/thread-tree-no-change.svg"}
 {/if}
 {/if}
-   <img class="icon" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/{$iconSrc}" alt="" width="14" height="14" />
+   <img class="icon{$wdClass}" src="{$FORUM_ADDRESS}/{$THEMES_DIR}/{$theme}/{$iconSrc}" alt="" width="14" height="14" />
    <span class="subject current">{$data.$element.subject}</span>
 {/if}
 


### PR DESCRIPTION
I found a few further issues with the icon code.

First there was a doubled definition for flipping icon images in case of displaying the forum in a language that is written from right to left. A second issue was the not flipped icon in front of the subject line of the currently displayed posting in the thread tree below the posting in the single posting view.