### PR TITLE
Formatting of the advanced search form

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -1828,6 +1828,9 @@ td ul.folded {
 	display: flex;
 	gap: 0.25em;
 }
+#advanced-search li{
+	padding-inline: 0 0.25em;
+}
 
 /* postings in search results: */
 ul.searchresults {

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -1821,6 +1821,13 @@ td ul.folded {
 	flex-wrap: wrap;
 	gap: 0.5em;
 }
+#advanced-search ul{
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	gap: 0.25em;
+}
 
 /* postings in search results: */
 ul.searchresults {

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -1814,6 +1814,14 @@ td ul.folded {
 	padding-inline-start 1em;
 }
 
+/* advanced search form */
+#advanced-search{
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 0.5em;
+}
+
 /* postings in search results: */
 ul.searchresults {
 	margin: 0 0 20px 0;

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -362,6 +362,7 @@ td ul.thread{margin:0;padding:0;list-style-type:none;font-size:1em!important}
 td ul.thread ul{font-size:.82em!important;line-height:1.25em}
 td ul.thread ul ul{font-size:1em!important}
 td ul.folded{margin:0;padding:0;padding-inline-start:1em}
+#advanced-search{display:flex;align-items:center;flex-wrap:wrap;gap:.5em}
 ul.searchresults{margin:0 0 20px;padding:0;list-style-type:none;max-width:100%!important}
 ul.searchresults li{font-size:1em;padding:0 0 10px}
 ul.searchresults li li{font-size:1em}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -363,6 +363,7 @@ td ul.thread ul{font-size:.82em!important;line-height:1.25em}
 td ul.thread ul ul{font-size:1em!important}
 td ul.folded{margin:0;padding:0;padding-inline-start:1em}
 #advanced-search{display:flex;align-items:center;flex-wrap:wrap;gap:.5em}
+#advanced-search ul{list-style:none;margin:0;padding:0;display:flex;gap:.25em}
 ul.searchresults{margin:0 0 20px;padding:0;list-style-type:none;max-width:100%!important}
 ul.searchresults li{font-size:1em;padding:0 0 10px}
 ul.searchresults li li{font-size:1em}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -364,6 +364,7 @@ td ul.thread ul ul{font-size:1em!important}
 td ul.folded{margin:0;padding:0;padding-inline-start:1em}
 #advanced-search{display:flex;align-items:center;flex-wrap:wrap;gap:.5em}
 #advanced-search ul{list-style:none;margin:0;padding:0;display:flex;gap:.25em}
+#advanced-search li{padding-inline:0 .25em}
 ul.searchresults{margin:0 0 20px;padding:0;list-style-type:none;max-width:100%!important}
 ul.searchresults li{font-size:1em;padding:0 0 10px}
 ul.searchresults li li{font-size:1em}

--- a/themes/default/subtemplates/search.inc.tpl
+++ b/themes/default/subtemplates/search.inc.tpl
@@ -1,5 +1,5 @@
 {if !$list_spam}
-<form action="index.php" method="get" accept-charset="{#charset#}">
+<form id="advanced-search" action="index.php" method="get" accept-charset="{#charset#}">
  <input type="hidden" name="mode" value="search" />
  <div>
   <label for="search_term">{#search_term#}</label>

--- a/themes/default/subtemplates/search.inc.tpl
+++ b/themes/default/subtemplates/search.inc.tpl
@@ -20,7 +20,7 @@
   <li><input id="searchfulltext" type="radio" name="method" value="0"{if $method == 'fulltext'} checked="checked"{/if} /><label for="searchfulltext">{#search_fulltext#}</label></li>
   <li><input id="searchtags" type="radio" class="search-radio" name="method" value="tags"{if $method == 'tags'} checked="checked"{/if} /><label for="searchtags">{#search_tags#}</label></li>
  </ul>{/if}
- <div>
+ <div class="buttonbar">
   <button name="search_submit" value="{#search_submit_button#}">{#search_submit_button#}</button>
  </div>
 </form>


### PR DESCRIPTION
The advanced search form has a bad styling after changing its HTML structure from putting the form elements side by side with putting them into table cells to residing in separate `div` elements. After this change the form was only formatted by the browser default styling.

The styling has been significantly improved with making the form itself being a flexbox and putting the `div` side by side again which can flow into new lines in narrow browser viewports.