### PR TITLE
Fixes for form lists of checkboxes and radiobuttons and the line height of a file list

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -925,10 +925,10 @@ form ul:has(li input[type="checkbox"], li input[type="radio"]) {
 
 ul.filelist {
 	list-style-type: none;
-	padding-left: 0;
-	margin-left: 0;
+	padding-inline-start: 0;
+	margin-inline-start: 0;
 	font-size: 0.82em;
-	line-height: 1.7em !important;
+	line-height: 1.7 !important;
 }
 ul.filelist img {
 	margin: 0 5px -3px 0;

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -907,10 +907,10 @@ fieldset.inactive label,
 fieldset.inactive input {
 	color: #808080;
 }
-.checkboxlist {
-	list-style-type:none;
-	margin: 0;
-	padding: 0;
+form ul:has(li input[type="checkbox"], li input[type="radio"]) {
+	list-style: none;
+	margin-inline: 0;
+	padding-inline: 0;
 	font-size: 1em !important;
 }
 .login {
@@ -1092,10 +1092,6 @@ p.userdata {
 }
 #postingform fieldset > *:not(:last-child) {
 	margin-block-end: 0.75em;
-}
-#postingform #sticky-selection {
-	padding-inline: 0;
-	list-style: none;
 }
 #postingform label.input {
 	display: block;

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -183,7 +183,7 @@ form ul:has(li input[type="checkbox"],li input[type="radio"]) {list-style:none;m
 .login{width:17em}
 .nowrap{white-space:nowrap}
 .user-locked{color:red!important}
-ul.filelist{list-style-type:none;padding-left:0;margin-left:0;font-size:.82em;line-height:1.7em!important}
+ul.filelist{list-style-type:none;padding-inline-start:0;margin-inline-start:0;font-size:.82em;line-height:1.7!important}
 ul.filelist img{margin:0 5px -3px 0;padding:0}
 ul.thread span.mod,ul.thread span.admin,td span.admin,td span.mod{cursor:help}
 .registered_user::after{content:" \00AE"}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -179,7 +179,7 @@ fieldset.active{border:none;margin:0;padding:0}
 fieldset.active label,fieldset.active input{color:#000}
 fieldset.inactive{border:none;margin:0;padding:0}
 fieldset.inactive label,fieldset.inactive input{color:gray}
-.checkboxlist{list-style-type:none;margin:0;padding:0;font-size:1em!important}
+form ul:has(li input[type="checkbox"],li input[type="radio"]) {list-style:none;margin-inline:0;padding-inline:0;font-size:1em!important}
 .login{width:17em}
 .nowrap{white-space:nowrap}
 .user-locked{color:red!important}
@@ -219,7 +219,6 @@ p.userdata{margin:0}
 #postingform fieldset:not(:last-child){margin-block:0 1em}
 #postingform fieldset > *{font-size:1em;margin:0;padding:0}
 #postingform fieldset > *:not(:last-child){margin-block-end:.75em}
-#postingform #sticky-selection{padding-inline:0;list-style:none}
 #postingform label.input{display:block;font-weight:700;margin-inline:0;margin-block:0 .25em}
 div#entry-input,#postingform input[type="text"],#postingform input[type="email"],#postingform input[type="url"],#postingform input[type="tel"]{max-width:calc(100vw - 4em)}
 #textarea-label{display:flex;justify-content:start;align-items:baseline;gap:.5em;margin-block:0 .25em}


### PR DESCRIPTION
The default theme uses multiple definitions for the styling of lists of checkboxes and radiobuttons in different forms. This is a first attempt to unify the styling under less definitions. There are several additional lists, that are only a bunch of inputs in table cells or paragraphs in table cells visually separated with `<br>` which has to be reworked. After rework those lists will automatically use the new styling definition.

I used the modern selector `:has()` which [is available](https://caniuse.com/css-has) since march 2022 (with Safari 15.4) for Apple users, the late summer of 2022 for all Chromium based browsers and since december 2023 for Firefix and its derivates. The last few users of older browsers see the lists in the typical HTML format with bullets in front of the list items. So there's nothing, that breaks.