### PR TITLE
Fix: remove comma at the parameters list of IntlDateFormatter

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1616,7 +1616,7 @@ function format_time($format, $timestamp = 0) {
 	$formatter = new IntlDateFormatter(
 		setlocale(LC_TIME, '0'),
 		IntlDateFormatter::FULL,
-		IntlDateFormatter::FULL,
+		IntlDateFormatter::FULL
 	);
 	$formatter->setPattern($format);
 	


### PR DESCRIPTION
Having a comma behind the last parameter of the object creation function is fine at least with PHP 8.1 and above because there I get no error message but while testing an upgrade beginning with MLF version 2.4.24, necessarily running under PHP 7.3, it causes a syntax error after finishing the upgrade and calling any page in the forum. Because an upgrade should be possible beginning with MLF version 2.4.19 this needed to be solved by removing the comma which causes the syntax error.