### PR TITLE
Add functions to determine the versions of PHP and the Database server

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2277,7 +2277,8 @@ function checkUpdate($currentVersion = '0.0') {
 }
 
 /**
- * checks the PHP version and writes the information into the table mlf2_temp_infos
+ * checks the PHP interpreter version
+ * and writes the information into the table mlf2_temp_infos
  *
  * @param connection $connid
  * @return bool
@@ -2301,7 +2302,8 @@ function getVersionPHP($connid) {
 }
 
 /**
- * checks the database server version and writes the information into the table mlf2_temp_infos
+ * checks the database server version
+ * and writes the information into the table mlf2_temp_infos
  *
  * @param connection $connid
  * @return bool

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -175,6 +175,7 @@ function daily_actions($current_time=0) {
 				@mysqli_query($connid, "INSERT INTO ".$db_settings['temp_infos_table']." (`name`, `value`) VALUES ('last_version_uri', '" . mysqli_real_escape_string($connid, $latestRelease->uri) . "') ON DUPLICATE KEY UPDATE `value` = '" . mysqli_real_escape_string($connid, $latestRelease->uri) . "';");
 			}
 		}
+		$savePHPVersion = getVersionPHP($connid);
 		
 		if (isset($settings) && isset($settings['notify_inactive_users']) && isset($settings['delete_inactive_users']) && $settings['notify_inactive_users'] > 0 && $settings['delete_inactive_users'] > 0)
 			handleInactiveUsers();
@@ -2269,6 +2270,30 @@ function checkUpdate($currentVersion = '0.0') {
 			);
 			return $release;
 		}
+	}
+	return false;
+}
+
+/**
+ * checks the PHP version and writes the information into the table mlf2_temp_infos
+ *
+ * @param connection $connid
+ * @return bool
+ */
+function getVersionPHP($connid) {
+	global $settings, $db_settings;
+	if ($connid === false) return false;
+	
+	if (defined("PHP_VERSION") && !empty(PHP_VERSION)) {
+		$query2 = "INSERT INTO ". $db_settings['temp_infos_table'] ."
+		(name, value, time)
+		VALUES ('php_version', '". mysqli_real_escape_string($connid, PHP_VERSION) ."', NOW())
+		ON DUPLICATE KEY UPDATE
+		value = '". mysqli_real_escape_string($connid, PHP_VERSION) ."',
+		time = NOW()";
+		$result2 = mysqli_query($connid, $query2);
+		
+		if ($result2 !== false) return true;
 	}
 	return false;
 }

--- a/includes/main.inc.php
+++ b/includes/main.inc.php
@@ -78,9 +78,6 @@ if (function_exists('date_default_timezone_set')) {
 	}
 }
 
-// do daily actions:
-//daily_actions(TIMESTAMP);
-
 $categories = get_categories();
 $category_ids = get_category_ids($categories);
 if ($category_ids != false) $category_ids_query = implode(', ', $category_ids);


### PR DESCRIPTION
In the functions `getVersionPHP` and `getVersionDB` the code determines the installed versions of the PHP interpreter respectively the database server. These information should be displayed in the admin panel.

See also #861 ands #860