### PR TITLE
Fix for broken generation of datetime values which are compatible with the datetime attribute of the HTML-element <time> 

### DIFF
--- a/includes/entry.inc.php
+++ b/includes/entry.inc.php
@@ -61,8 +61,8 @@
 				$entrydata['thread_locked'] = 1;
 			}
 			
-			$entrydata['ISO_time']      = format_time('YYYY-MM-dd HH:mm:ss', $entrydata['time']);
-			$entrydata['edit_ISO_time'] = format_time('YYYY-MM-dd HH:mm:ss', $entrydata['etime']);
+			$entrydata['ISO_time']      = date(DATE_ATOM, $entrydata['time']);
+			$entrydata['edit_ISO_time'] = date(DATE_ATOM, $entrydata['etime']);
 			$entrydata['formated_time'] = format_time($lang['time_format_full'], $entrydata['disp_time']);
 			$entrydata['tags']          = getEntryTags($id);
 			
@@ -171,7 +171,7 @@
 		
 		$data['subject']       = htmlspecialchars($data['subject']);
 		$data['formated_time'] = format_time($lang['time_format'], $data['disp_time']);
-		$data['ISO_time']      = format_time('YYYY-MM-dd HH:mm:ss', $data['time']);
+		$data['ISO_time']      = date(DATE_ATOM, $data['time']);
 		
 		// set read or new status of messages
 		$data = getMessageStatus($data, $last_visit);

--- a/includes/index.inc.php
+++ b/includes/index.inc.php
@@ -143,7 +143,7 @@ if ($result_count > 0) {
 			$data = getMessageStatus($data, $last_visit, $fold_threads);
 			// convert formated time to a utf-8:
 			$data['formated_time'] = format_time($lang['time_format'], $data['timestamp']);
-			$data['ISO_time'] = format_time('YYYY-MM-dd HH:mm:ss', $data['time']);
+			$data['ISO_time'] = date(DATE_ATOM, $data['time']);
 			// set key 'not_classified_spam_ham' to decide, if an mod or admin should get notified about need of classification with an icon
 			if ((isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$settings['session_prefix'].'user_type']) && $_SESSION[$settings['session_prefix'].'user_type'] >= 1) && (($settings['akismet_entry_check'] == 1 && $data['akismet_checked'] == 0) || ($settings['b8_entry_check'] == 1 && $data['b8_checked'] == 0))) {
 			  $data['not_classified_spam_ham'] = 1;

--- a/includes/posting.inc.php
+++ b/includes/posting.inc.php
@@ -1210,7 +1210,7 @@ switch ($action) {
 				// current time:
 				list($preview_time) = mysqli_fetch_row(mysqli_query($connid, "SELECT UNIX_TIMESTAMP(NOW() + INTERVAL " . $time_difference . " MINUTE)"));
 				$smarty->assign('preview_timestamp', $preview_time);
-				$preview_ISO_time = format_time('YYYY-MM-dd HH:mm:ss', $posting_time);
+				$preview_ISO_time = date(DATE_ATOM, $posting_time);
 				$smarty->assign('preview_ISO_time', $preview_ISO_time);
 				$preview_formated_time = format_time($lang['time_format_full'], $posting_time);
 				$smarty->assign('preview_formated_time', $preview_formated_time);
@@ -1651,7 +1651,7 @@ switch ($action) {
 				$smarty->assign('pid', intval($field['pid']));
 				$smarty->assign('name', htmlspecialchars($field['name']));
 				$smarty->assign('subject', htmlspecialchars($field['subject']));
-				$smarty->assign('ISO_time', htmlspecialchars(format_time('YYYY-MM-dd HH:mm:ss', $field['time'])));
+				$smarty->assign('ISO_time', htmlspecialchars(date(DATE_ATOM, $field['time'])));
 				$smarty->assign('formated_time', htmlspecialchars(format_time($lang['time_format_full'], $field['disp_time'])));
 				$smarty->assign('akismet_spam', intval($field['akismet_spam']));
 				$smarty->assign('akismet_spam_check_status', intval($field['spam_check_status']));
@@ -1780,7 +1780,7 @@ switch ($action) {
 				$smarty->assign('pid', intval($field['pid']));
 				$smarty->assign('name', htmlspecialchars($field['name']));
 				$smarty->assign('subject', htmlspecialchars($field['subject']));
-				$smarty->assign('ISO_time', htmlspecialchars(format_time('YYYY-MM-dd HH:mm:ss', $field['time'])));
+				$smarty->assign('ISO_time', htmlspecialchars(date(DATE_ATOM, $field['time'])));
 				$smarty->assign('formated_time', htmlspecialchars(format_time($lang['time_format_full'], $field['disp_time'])));
 				$smarty->assign('akismet_spam', intval($field['akismet_spam']));
 				$smarty->assign('akismet_spam_check_status', intval($field['spam_check_status']));

--- a/includes/thread.inc.php
+++ b/includes/thread.inc.php
@@ -127,7 +127,7 @@ if (is_array($category_ids) && !in_array($data['category'], $category_ids)) {
 					$data['tags'] = $tags_array;
 			}
 			$data['formated_time'] = format_time($lang['time_format_full'], $data['disp_time']);
-			$data['ISO_time']      = format_time('YYYY-MM-dd HH:mm:ss', $data['time']);
+			$data['ISO_time']      = date(DATE_ATOM, $data['time']);
 			$data['thread_locked'] = $thread_locked;
 			
 			$ago['days']           = floor((TIMESTAMP - $data['time']) / 86400);
@@ -179,7 +179,7 @@ if (is_array($category_ids) && !in_array($data['category'], $category_ids)) {
 			if ($data['edited_diff'] > 0 && $data["edited_diff"] > $data["time"] && $settings['show_if_edited'] == 1) {
 				$data['edited']             = true;
 				$data['formated_edit_time'] = format_time($lang['time_format_full'], $data['e_time']);
-				$data['ISO_edit_time']      = format_time('YYYY-MM-dd HH:mm:ss', $data['edited_time']);
+				$data['ISO_edit_time']      = date(DATE_ATOM, $data['edited_time']);
 				if ($data['user_id'] == $data['edited_by'])
 					$data['edited_by'] = $data['name'];
 				else {


### PR DESCRIPTION
Replace IntlDateFormatter with function `date` with the format `DATE_ATOM` to generate a machine readable value for `<time datetime="">` in the format `2025-10-27T18:15:45+01:00`. The IntlDateFormatter returned always a localised datetime string, even if not wanted. This worked for languages with the arabic numbers known from the latin and kyrillic based languages but i.e. not the numbers which are used in arabic language(s).

fixes #873 