### PR TITLE
Make the 'i' in the info icon more recognisable

### DIFF
--- a/themes/default/images/general-information.svg
+++ b/themes/default/images/general-information.svg
@@ -11,7 +11,7 @@
   svg { fill: transparent; }
   #face { fill: url(#head); stroke: #fcfcfc; stroke-width: 8; }
   #border { fill: none; stroke: #08af38; stroke-width: 12; }
-  #eye, #letter { fill: #eeeb; stroke-width: 8; stroke: #fcfcfc; stroke-linejoin: round; }
+  #eye, #letter { fill: #eeee; stroke-width: 8; stroke: #fcfcfc; stroke-linejoin: round; }
   ]]>
  </style>
  <circle id="border" cx="132" cy="132" r="122" />


### PR DESCRIPTION
While the icon is easily recognisable in its original size, the '*I*' is no longer clearly visible when the icon is limited to the line height of an element's font. I therefore made the '*I*' brighter, which improves the contrast.