### PR TITLE
Next bunch of CSS optimisations

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -1949,17 +1949,17 @@ form .hp {
 	#main-grid.threaded:has(aside.js-display-fold) {
 		grid-template-columns: auto 8.5em;
 }
-	h2.sidebar a {
+	.threaded h2.sidebar a {
 		padding-inline: 1.25em 0.375em;
 		background: url("images/triangle-full-right.svg") 0.175em center/0.9em 0.9em no-repeat;
 }
-	.js-display-fold h2.sidebar a {
+	.threaded .js-display-fold h2.sidebar a {
 		background: url("images/triangle-full-left.svg") 0.325em center/0.9em 0.9em no-repeat;
 }
-	html[dir="rtl"] h2.sidebar a {
+	html[dir="rtl"] .threaded h2.sidebar a {
 		background: url("images/triangle-full-left.svg") calc(100% - 0.175em) center/0.9em 0.9em no-repeat;
 }
-	html[dir="rtl"] .js-display-fold h2.sidebar a {
+	html[dir="rtl"] .threaded .js-display-fold h2.sidebar a {
 		background: url("images/triangle-full-right.svg") calc(100% - 0.175em) center/0.9em 0.9em no-repeat;
 }
 }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -390,11 +390,11 @@ form .hp{display:none}
 	#sidebar{width:100%}
 	#admin-main-menu{grid-template-areas:"infoboxes mainmenu";grid-template-columns:18em auto;grid-template-rows:auto}
 	#main-grid.threaded {grid-template-areas:"threadlist sidebar";grid-template-columns:auto 18em;grid-template-rows:auto}
-	h2.sidebar a{padding-inline:1.25em .375em;background:url("images/triangle-full-right.svg") 0.175em center/0.9em 0.9em no-repeat}
-	.js-display-fold h2.sidebar a{background:url("images/triangle-full-left.svg") 0.325em center/0.9em 0.9em no-repeat}
-	html[dir="rtl"] h2.sidebar a{background:url("images/triangle-full-left.svg") calc(100% - 0.175em) center/0.9em 0.9em no-repeat}
-	html[dir="rtl"] .js-display-fold h2.sidebar a{background:url("images/triangle-full-right.svg") calc(100% - 0.175em) center/0.9em 0.9em no-repeat}
 	#main-grid.threaded:has(aside.js-display-fold){grid-template-columns:auto 8.5em}
+	.threaded h2.sidebar a{padding-inline:1.25em .375em;background:url("images/triangle-full-right.svg") 0.175em center/0.9em 0.9em no-repeat}
+	.threaded .js-display-fold h2.sidebar a{background:url("images/triangle-full-left.svg") 0.325em center/0.9em 0.9em no-repeat}
+	html[dir="rtl"] .threaded h2.sidebar a{background:url("images/triangle-full-left.svg") calc(100% - 0.175em) center/0.9em 0.9em no-repeat}
+	html[dir="rtl"] .threaded .js-display-fold h2.sidebar a{background:url("images/triangle-full-right.svg") calc(100% - 0.175em) center/0.9em 0.9em no-repeat}
 }
 @media screen and (min-width:48em) {
 	#logo h1{font-size:1.6em}


### PR DESCRIPTION
The identical rules for the blocks with additional information on the overview pages, in the admin panel and in the user list have been summarised. The HTML structure of the sidebar on the thread overviews has been simplified somewhat by removing the `div#sidebarcontent`. In addition, two fixes for errors in the CSS rules for the sidebar have been added.