### PR TITLE
Remove the flexible font size and set a slightly larger default size

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -19,8 +19,7 @@ body {
 	padding: 0;
 	text-align: start;
 	font-family: verdana, arial, sans-serif;
-	font-size: 1em;
-	font-size: clamp(1rem, 0.7rem + 0.7vw, 1.2rem);
+	font-size: 1.125rem;
 	display: flex;
 	flex-direction: column;
 	min-height: 100vh;

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -1,5 +1,5 @@
 *,::before,::after{box-sizing:border-box}
-body{color:#000;background:#f9f9f9;margin:0;padding:0;text-align:start;font-family:verdana,arial,sans-serif;font-size:1em;font-size:clamp(1rem,.7rem + .7vw,1.2rem);display:flex;flex-direction:column;min-height:100vh}
+body{color:#000;background:#f9f9f9;margin:0;padding:0;text-align:start;font-family:verdana,arial,sans-serif;font-size:1.125rem;display:flex;flex-direction:column;min-height:100vh}
 .small{font-size:.86em}
 .xsmall{font-size:.74em}
 h1{margin-top:0;font-size:1.25em;font-weight:700}


### PR DESCRIPTION
The flexible viewport width dependent font size may be reintroduced at a later time. Instead increase the font size from 1em to 1.125rem for now.