### PR TITLE
Fix: reset the pagination on the overview pages to page 1

### DIFF
--- a/includes/main.inc.php
+++ b/includes/main.inc.php
@@ -183,6 +183,14 @@ if(isset($_GET['refresh'])) {
 if (isset($_GET['show_spam']) && isset($_SESSION[$settings['session_prefix'].'user_id']) && $_SESSION[$settings['session_prefix'].'user_id'] > 0) {
 	if (isset($_SESSION[$settings['session_prefix'].'usersettings']['show_spam'])) unset($_SESSION[$settings['session_prefix'].'usersettings']['show_spam']);
 	else $_SESSION[$settings['session_prefix'].'usersettings']['show_spam'] = true;
+	// reset the page number to 1
+	// moving to the list of spam postings can fail
+	// if one starts from a paginated overview page
+	// one can lands on an probably empty spam overview page
+	// because there aren't so many spam posts
+	// that they reach the same paginated page
+	// whith that quick fix one lands reliable on page 1
+	$_SESSION[$settings['session_prefix'].'usersettings']['page'] = 1;
 	header('location: index.php?mode=index');
 	exit;
 }


### PR DESCRIPTION
When switching on the overview page to the list of postings, suspected to be spam, one lands on the page that corresponds to the page one is coming from. If one is in example on page 5 of the overview one lands on page 5 of the spam listing, even there are not enough cases of spam suspicion to show content on page 5. With this fix the software resets the pagination simply to page 1. For further details see issue #621.

Ths fixes #621