### PR TITLE
Remove further font size definitions

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -75,7 +75,7 @@ a.boldlink {
 	font-weight: bold;
 }
 
-:is(a, span, button):has(img.icon) {
+:is(a, span, button, legend):has(img.icon) {
 	display: flex;
 	align-items: center;
 	gap: 0.125em;

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -12,7 +12,7 @@ a:visited{color:#00c}
 a:focus,a:hover{color:#00f;text-decoration:underline}
 a:active{color:red}
 a.boldlink{font-weight:bold}
-:is(a,span,button):has(img.icon){display:flex;align-items:center;gap:.125em}
+:is(a,span,button,legend):has(img.icon){display:flex;align-items:center;gap:.125em}
 html[dir="rtl"] img.icon.wd-dependent{transform:scale(-1,1)}
 img:is(.icon,.sa-icon){width:.875em;height:auto}
 .tail a img{width:.75em;height:auto}


### PR DESCRIPTION
Remove a few exceptions from and a redefinition of default font size. Furthermore remove code blocks of selectors for non existing elements. Laast but not least apply the definitions for elements of types `a`, `span` and `button` with images matching `img.icon` in it als to elements of type `legend`.