### PR TITLE
Style icons in span in a postings .tail

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -87,7 +87,7 @@ img:is(.icon, .sa-icon) {
 	width: 0.875em;
 	height: auto;
 }
-.tail a img {
+.tail :is(a img,span img) {
 	width: 0.75em;
 	height: auto;
 }

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -15,7 +15,7 @@ a.boldlink{font-weight:bold}
 :is(a,span,button,legend):has(img.icon){display:flex;align-items:center;gap:.125em}
 html[dir="rtl"] img.icon.wd-dependent{transform:scale(-1,1)}
 img:is(.icon,.sa-icon){width:.875em;height:auto}
-.tail a img{width:.75em;height:auto}
+.tail :is(a img,span img){width:.75em;height:auto}
 select,input,button,textarea{font-size:initial}
 body > *{margin:0;padding:0 1em;padding:0 1rem}
 #top{background:#d2ddea;background: linear-gradient(to bottom, rgb(210, 222, 236) 0, rgb(237, 242, 245) 2.5em, rgb(237, 242, 245) 100%);display:flex;flex-direction:column;padding-block:.5em}


### PR DESCRIPTION
Icons in the tail of a posting in a thread tree are styled regarding to their size. I forgot to include the no-text icon which is contained in a `span` and not in a link (`a`) like the other icons. With this pull request this bug gets fixed.