### PR TITLE
Restyle the threaded posting views

### DIFF
--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -553,9 +553,6 @@ blockquote code {
 	padding-inline: 0.625em;
 	padding-block: 0.25em;
 }
-.new {
-	border-color: #88a9cf;
-}
 .thread-posting h1,
 .thread-posting h2 {
 	margin: 0 0 2px 0;
@@ -612,6 +609,9 @@ blockquote code {
 	margin-inline: 5px 0;
 	padding: 0;
 	list-style-type: none;
+}
+.new {
+	border-color: #88a9cf;
 }
 
 .op-link {

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -107,7 +107,6 @@ blockquote code{font-family:"courier new",courier;color:#6f6f6f}
 .posting-footer a{white-space:nowrap}
 .thread-posting{position:relative;border:1px solid;border-inline-start:10px solid;border-color:#d2ddea;margin-block:0 .875em;padding:0;background:#fff}
 .thread-posting > *{padding-inline:.625em;padding-block:.25em}
-.new{border-color:#88a9cf}
 .thread-posting h1,.thread-posting h2{margin:0 0 2px;padding:0;font-size:1.05em}
 .thread-posting .header{background:#f5f5f5;margin:0}
 .thread-posting img.avatar{position:relative;margin:0 .75em .75em .75em;padding:.25em;background:#f5f5f5;float:right;float:inline-end}
@@ -118,6 +117,7 @@ blockquote code{font-family:"courier new",courier;color:#6f6f6f}
 .reply-wrapper{margin-block:0;margin-inline:20px 0;padding:0;list-style-type:none}
 .deep-reply-wrapper{margin-block:0;margin-inline:10px 0;padding:0;list-style-type:none}
 .very-deep-reply-wrapper{margin-block:0;margin-inline:5px 0;padding:0;list-style-type:none}
+.new{border-color:#88a9cf}
 .op-link{font-size:.86em}
 .op-link a{color:gray}
 #content .body,#content .body > *:not([popover]){display:flow-root}


### PR DESCRIPTION
The "threaded posting views" means the displaying of all posts of a thread together in a nested view or in a flat view like in a message board. This PR generally changes the margins and paddings of the affected elements from pixel based to em-based values, simplifies the rules for the borders of the posting articles, summarises the previously scattered rules for margins and paddings of the children of the article element in a single set of rules and changes the margins and paddings of the avatar images as well as resizes them in case of folded postings.