### PR TITLE
New function for image file validation

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1499,6 +1499,7 @@ function resize_image($uploaded_file, $file, $new_width, $new_height, $compressi
 		@chmod($file, 0744);
 	}
 	
+	$error = false
 	$image_info = getimagesize($uploaded_file);
 	$imageMIME = mime_content_type($uploaded_file);
 	if (!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png', 'image/webp'])) $error = true;
@@ -1507,15 +1508,15 @@ function resize_image($uploaded_file, $file, $new_width, $new_height, $compressi
 		if ($imageMIME == 'image/gif') {
 			// image of type GIF
 			$current_image = @imagecreatefromgif($uploaded_file) or $error = true;
-			if (empty($error)) $new_image = @imagecreate($new_width, $new_height) or $error = true;
-			if (empty($error)) @imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
-			if (empty($error)) @imagegif($new_image, $file) or $error = true;
+			if ($error === false) $new_image = @imagecreate($new_width, $new_height) or $error = true;
+			if ($error === false) @imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
+			if ($error === false) @imagegif($new_image, $file) or $error = true;
 		} elseif ($imageMIME == 'image/jpeg') {
 			// image of type JPG
 			$current_image = @imagecreatefromjpeg($uploaded_file) or $error = true;
-			if (empty($error)) $new_image = @imagecreatetruecolor($new_width, $new_height) or $error = true;
-			if (empty($error)) @imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
-			if (empty($error)) @imagejpeg($new_image, $file, $compression) or $error = true;
+			if ($error === false) $new_image = @imagecreatetruecolor($new_width, $new_height) or $error = true;
+			if ($error === false) @imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
+			if ($error === false) @imagejpeg($new_image, $file, $compression) or $error = true;
 		} elseif($imageMIME=='image/png') {
 			// image of type PNG
 			//translate $compression into one of the nine compression steps for PNG
@@ -1529,18 +1530,18 @@ function resize_image($uploaded_file, $file, $new_width, $new_height, $compressi
 				$compressPNG = 9;
 			}
 			$current_image = imagecreatefrompng($uploaded_file) or $error = true;
-			if (empty($error)) $new_image = imagecreatetruecolor($new_width, $new_height) or $error = true;
-			if (empty($error)) imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
-			if (empty($error)) imagepng($new_image, $file, $compressPNG) or $error = $true;
+			if ($error === false) $new_image = imagecreatetruecolor($new_width, $new_height) or $error = true;
+			if ($error === false) imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
+			if ($error === false) imagepng($new_image, $file, $compressPNG) or $error = $true;
 		} elseif($imageMIME=='image/webp') {
 			// image of type WebP
 			$current_image = imagecreatefromwebp($uploaded_file) or $error = true;
-			if (empty($error)) $new_image = imagecreatetruecolor($new_width, $new_height) or $error = true;
-			if (empty($error)) imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
-			if (empty($error)) imagewebp($new_image, $file, $compression) or $error = $true;
+			if ($error === false) $new_image = imagecreatetruecolor($new_width, $new_height) or $error = true;
+			if ($error === false) imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
+			if ($error === false) imagewebp($new_image, $file, $compression) or $error = $true;
 		}
 	}
-	if (empty($error)) return true;
+	if ($error === false) return true;
 	else return false;
 }
 

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1499,7 +1499,7 @@ function resize_image($uploaded_file, $file, $new_width, $new_height, $compressi
 		@chmod($file, 0744);
 	}
 	
-	$error = false
+	$error = false;
 	$image_info = getimagesize($uploaded_file);
 	$imageMIME = mime_content_type($uploaded_file);
 	if (!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png', 'image/webp']))  return false;

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1528,16 +1528,16 @@ function resize_image($uploaded_file, $file, $new_width, $new_height, $compressi
 		} else {
 			$compressPNG = 9;
 		}
-		$current_image = imagecreatefrompng($uploaded_file) or $error = true;
-		if ($error === false) $new_image = imagecreatetruecolor($new_width, $new_height) or $error = true;
-		if ($error === false) imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
-		if ($error === false) imagepng($new_image, $file, $compressPNG) or $error = $true;
+		$current_image = @imagecreatefrompng($uploaded_file) or $error = true;
+		if ($error === false) $new_image = @imagecreatetruecolor($new_width, $new_height) or $error = true;
+		if ($error === false) @imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
+		if ($error === false) @imagepng($new_image, $file, $compressPNG) or $error = $true;
 	} elseif($imageMIME=='image/webp') {
 		// image of type WebP
-		$current_image = imagecreatefromwebp($uploaded_file) or $error = true;
-		if ($error === false) $new_image = imagecreatetruecolor($new_width, $new_height) or $error = true;
-		if ($error === false) imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
-		if ($error === false) imagewebp($new_image, $file, $compression) or $error = $true;
+		$current_image = @imagecreatefromwebp($uploaded_file) or $error = true;
+		if ($error === false) $new_image = @imagecreatetruecolor($new_width, $new_height) or $error = true;
+		if ($error === false) @imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
+		if ($error === false) @imagewebp($new_image, $file, $compression) or $error = $true;
 	}
 	if ($error === false) return true;
 	else return false;

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2623,7 +2623,7 @@ function setReceiptTimestamp($offset = 0) {
 }
 
 /**
- * function to validate an image, given by the temporary file name
+ * function to validate an image $image and save it with $savePath
  *
  * Check if an image is of one of the allowed image types.
  * Allowed are the filetypes GIF, JPEG, PNG, WebP.
@@ -2635,7 +2635,7 @@ function setReceiptTimestamp($offset = 0) {
  * @return bool [false]
  * @return string [mimetype]
  */
-function validate_image($image, $savePath) {
+function write_image($image, $savePath) {
 	// set the working variable for the file type check
 	$isImg = false;
 	$imgTmp = false;

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2644,19 +2644,31 @@ function validate_image($image, $savePath) {
 	switch($type) {
 		case 1:
 			// GIF
-			$isImg = imagecreatefromgif($image);
+			$imgTmp = imagecreatefromgif($image);
+			if ($imgTmp !== false) {
+				$isImg = imagegif($imgTmp, $savePath);
+			}
 		break;
 		case 2:
 			//JPEG
-			$isImg = imagecreatefromjpeg($image);
+			$imgTmp = imagecreatefromjpeg($image);
+			if ($imgTmp !== false) {
+				$isImg = imagejpeg($imgTmp, $savePath, 100);
+			}
 		break;
 		case 3:
 			// PNG
-			$isImg = imagecreatefrompng($image);
+			$imgTmp = imagecreatefrompng($image);
+			if ($imgTmp !== false) {
+				$isImg = imagepng($imgTmp, $savePath, 6);
+			}
 		break;
 		case 18:
 			// WebP
-			$isImg = imagecreatefromwebp($image);
+			$imgTmp = imagecreatefromwebp($image);
+			if ($imgTmp !== false) {
+				$isImg = imagewebp($imgTmp, $savePath, 100);
+			}
 		break;
 		default:
 			// not allowed filetype

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2676,6 +2676,7 @@ function validate_image($image, $savePath) {
 	}
 	$type = ($isImg === false) ? false : true; 
 	return $type;
+	if ($isImg === false) return false;
 }
 
 

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2629,11 +2629,7 @@ function is_valid_image_type($image) {
 	// does the file in itself exist?
 	if (!file_exists($image)) return false;
 	// what is the mimetype of the file?
-	$finfo = finfo_open(FILEINFO_MIME_TYPE);
-	if ($finfo) {
-		$isImg = finfo_file($finfo, $image);
-		finfo_close($finfo);
-	}
+	$isImg = mime_content_type($image);
 	if (!in_array($isImg, ['image/gif', 'image/jpeg', 'image/png', 'image/webp'])) return false;
 	// what is the imagetype constant?
 	$type = exif_imagetype($image);

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2615,9 +2615,12 @@ function setReceiptTimestamp($offset = 0) {
 }
 
 /**
- * function to validate of an image, given by file name is really an image of one of the allowed image types
+ * function to validate an image, given by the temporary file name
  *
- * allowed are the filetypes GIF, JPEG, PNG, WebP
+ * Check if an image is of one of the allowed image types.
+ * Allowed are the filetypes GIF, JPEG, PNG, WebP.
+ * Recode the input image to ensure, that it is really an image
+ * and not i.e. a malicious script, that is enclosed in an image.
  *
  * @return bool [false|true]
  * @param ressource $image the image name, taken from the $_FILES array

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2615,6 +2615,46 @@ function setReceiptTimestamp($offset = 0) {
 }
 
 /**
+ * function to validate of an image, given by file name is really an image of one of the allowed image types
+ *
+ * allowed are the filetypes GIF, JPEG, PNG, WebP
+ *
+ * @param string $image path to an image file
+ * @return bool [false|true]
+ */
+function is_valid_image_type($image) {
+	if (!file_exists($image)) return false;
+	$type = exif_imagetype($image);
+	if ($type === false) return false;
+	$isImg = false;
+	
+	switch($type) {
+		case 1:
+			// GIF
+			$isImg = imagecreatefromgif($image);
+		break;
+		case 2:
+			//JPEG
+			$isImg = imagecreatefromjpeg($image);
+		break;
+		case 3:
+			// PNG
+			$isImg = imagecreatefrompng($image);
+		break;
+		case 18:
+			// WebP
+			$isImg = imagecreatefromwebp($image);
+		break;
+		default:
+			// not allowed filetype
+			$isImg = false;
+	}
+	$type = ($isImg === false) ? false : true; 
+	return $type;
+}
+
+
+/**
  * sends a status code, displays an error message and halts the script
  *
  * @param string $status_code

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1496,7 +1496,7 @@ function move_item($table, $id, $direction) {
  */
 function resize_image($uploaded_file, $file, $new_width, $new_height, $compression=80) {
 	if (file_exists($file)) {
-		@chmod($file, 0777);
+		@chmod($file, 0744);
 	}
 	
 	$image_info = getimagesize($uploaded_file);

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2635,8 +2635,8 @@ function validate_image($image, $savePath) {
 	// does the temporary file in itself exist?
 	if (!file_exists($image)) return false;
 	// what is the mimetype of the file?
-	$isImg = mime_content_type($image);
-	if (!in_array($isImg, ['image/gif', 'image/jpeg', 'image/png', 'image/webp'])) return false;
+	$mimeImg = mime_content_type($image);
+	if (!in_array($mimeImg, ['image/gif', 'image/jpeg', 'image/png', 'image/webp'])) return false;
 	// what is the imagetype constant?
 	$type = exif_imagetype($image);
 	if ($type === false) return false;

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1497,7 +1497,6 @@ function move_item($table, $id, $direction) {
 function resize_image($uploaded_file, $file, $new_width, $new_height, $compression=80) {
 	if (file_exists($file)) {
 		@chmod($file, 0777);
-		@unlink($file);
 	}
 	
 	$image_info = getimagesize($uploaded_file);

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2623,10 +2623,21 @@ function setReceiptTimestamp($offset = 0) {
  * @return bool [false|true]
  */
 function is_valid_image_type($image) {
+	// set the working variable for the file type check
+	$isImg = false;
+	
+	// does the file in itself exist?
 	if (!file_exists($image)) return false;
+	// what is the mimetype of the file?
+	$finfo = finfo_open(FILEINFO_MIME_TYPE);
+	if ($finfo) {
+		$isImg = finfo_file($finfo, $image);
+		finfo_close($finfo);
+	}
+	if (!in_array($isImg, ['image/gif', 'image/jpeg', 'image/png', 'image/webp'])) return false;
+	// what is the imagetype constant?
 	$type = exif_imagetype($image);
 	if ($type === false) return false;
-	$isImg = false;
 	
 	switch($type) {
 		case 1:

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2622,9 +2622,10 @@ function setReceiptTimestamp($offset = 0) {
  * Recode the input image to ensure, that it is really an image
  * and not i.e. a malicious script, that is enclosed in an image.
  *
- * @return bool [false|true]
  * @param ressource $image the image name, taken from the $_FILES array
  * @param string $savePath path to the saving location of the resulting image file
+ * @return bool [false]
+ * @return array [success status (true), mimetype]
  */
 function validate_image($image, $savePath) {
 	// set the working variable for the file type check
@@ -2674,9 +2675,9 @@ function validate_image($image, $savePath) {
 			// not allowed filetype
 			$isImg = false;
 	}
-	$type = ($isImg === false) ? false : true; 
-	return $type;
 	if ($isImg === false) return false;
+	$imageInfo = ["valid" => $isImg, "mimeType" => $mimeImg];
+	return $imageInfo;
 }
 
 

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1518,10 +1518,20 @@ function resize_image($uploaded_file, $file, $new_width, $new_height, $compressi
 			if (empty($error)) @imagejpeg($new_image, $file, $compression) or $error = true;
 		} elseif($imageMIME=='image/png') {
 			// image of type PNG
+			//translate $compression into one of the nine compression steps for PNG
+			if (in_array($compression, range(100, 91, -1))) {
+				$compressPNG = 6;
+			} else if (in_array($compression, range(90, 81, -1))) {
+				$compressPNG = 7;
+			} else if (in_array($compression, range(80, 71, -1))) {
+				$compressPNG = 8;
+			} else {
+				$compressPNG = 9;
+			}
 			$current_image = imagecreatefrompng($uploaded_file) or $error = true;
 			if (empty($error)) $new_image = imagecreatetruecolor($new_width, $new_height) or $error = true;
 			if (empty($error)) imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
-			if (empty($error)) imagepng($new_image, $file) or $error = $true;
+			if (empty($error)) imagepng($new_image, $file, $compressPNG) or $error = $true;
 		} elseif($imageMIME=='image/webp') {
 			// image of type WebP
 			$current_image = imagecreatefromwebp($uploaded_file) or $error = true;

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1502,7 +1502,7 @@ function resize_image($uploaded_file, $file, $new_width, $new_height, $compressi
 	$error = false
 	$image_info = getimagesize($uploaded_file);
 	$imageMIME = mime_content_type($uploaded_file);
-	if (!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png', 'image/webp'])) $error = true;
+	if (!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png', 'image/webp']))  return false;
 	
 	if (empty($error)) {
 		if ($imageMIME == 'image/gif') {

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2632,7 +2632,7 @@ function validate_image($image, $savePath) {
 	$imgTmp = false;
 	$imageInfo = ["valid" => false, "mimetype" => false];
 	
-	// does the file in itself exist?
+	// does the temporary file in itself exist?
 	if (!file_exists($image)) return false;
 	// what is the mimetype of the file?
 	$isImg = mime_content_type($image);

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2619,10 +2619,11 @@ function setReceiptTimestamp($offset = 0) {
  *
  * allowed are the filetypes GIF, JPEG, PNG, WebP
  *
- * @param string $image path to an image file
  * @return bool [false|true]
+ * @param ressource $image the image name, taken from the $_FILES array
+ * @param string $savePath path to the saving location of the resulting image file
  */
-function is_valid_image_type($image) {
+function is_valid_image_type($image, $savePath) {
 	// set the working variable for the file type check
 	$isImg = false;
 	

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2623,7 +2623,7 @@ function setReceiptTimestamp($offset = 0) {
  * @param ressource $image the image name, taken from the $_FILES array
  * @param string $savePath path to the saving location of the resulting image file
  */
-function is_valid_image_type($image, $savePath) {
+function validate_image($image, $savePath) {
 	// set the working variable for the file type check
 	$isImg = false;
 	

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1504,42 +1504,40 @@ function resize_image($uploaded_file, $file, $new_width, $new_height, $compressi
 	$imageMIME = mime_content_type($uploaded_file);
 	if (!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png', 'image/webp']))  return false;
 	
-	if (empty($error)) {
-		if ($imageMIME == 'image/gif') {
-			// image of type GIF
-			$current_image = @imagecreatefromgif($uploaded_file) or $error = true;
-			if ($error === false) $new_image = @imagecreate($new_width, $new_height) or $error = true;
-			if ($error === false) @imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
-			if ($error === false) @imagegif($new_image, $file) or $error = true;
-		} elseif ($imageMIME == 'image/jpeg') {
-			// image of type JPG
-			$current_image = @imagecreatefromjpeg($uploaded_file) or $error = true;
-			if ($error === false) $new_image = @imagecreatetruecolor($new_width, $new_height) or $error = true;
-			if ($error === false) @imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
-			if ($error === false) @imagejpeg($new_image, $file, $compression) or $error = true;
-		} elseif($imageMIME=='image/png') {
-			// image of type PNG
-			//translate $compression into one of the nine compression steps for PNG
-			if (in_array($compression, range(100, 91, -1))) {
-				$compressPNG = 6;
-			} else if (in_array($compression, range(90, 81, -1))) {
-				$compressPNG = 7;
-			} else if (in_array($compression, range(80, 71, -1))) {
-				$compressPNG = 8;
-			} else {
-				$compressPNG = 9;
-			}
-			$current_image = imagecreatefrompng($uploaded_file) or $error = true;
-			if ($error === false) $new_image = imagecreatetruecolor($new_width, $new_height) or $error = true;
-			if ($error === false) imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
-			if ($error === false) imagepng($new_image, $file, $compressPNG) or $error = $true;
-		} elseif($imageMIME=='image/webp') {
-			// image of type WebP
-			$current_image = imagecreatefromwebp($uploaded_file) or $error = true;
-			if ($error === false) $new_image = imagecreatetruecolor($new_width, $new_height) or $error = true;
-			if ($error === false) imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
-			if ($error === false) imagewebp($new_image, $file, $compression) or $error = $true;
+	if ($imageMIME == 'image/gif') {
+		// image of type GIF
+		$current_image = @imagecreatefromgif($uploaded_file) or $error = true;
+		if ($error === false) $new_image = @imagecreate($new_width, $new_height) or $error = true;
+		if ($error === false) @imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
+		if ($error === false) @imagegif($new_image, $file) or $error = true;
+	} elseif ($imageMIME == 'image/jpeg') {
+		// image of type JPG
+		$current_image = @imagecreatefromjpeg($uploaded_file) or $error = true;
+		if ($error === false) $new_image = @imagecreatetruecolor($new_width, $new_height) or $error = true;
+		if ($error === false) @imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
+		if ($error === false) @imagejpeg($new_image, $file, $compression) or $error = true;
+	} elseif($imageMIME=='image/png') {
+		// image of type PNG
+		//translate $compression into one of the nine compression steps for PNG
+		if (in_array($compression, range(100, 91, -1))) {
+			$compressPNG = 6;
+		} else if (in_array($compression, range(90, 81, -1))) {
+			$compressPNG = 7;
+		} else if (in_array($compression, range(80, 71, -1))) {
+			$compressPNG = 8;
+		} else {
+			$compressPNG = 9;
 		}
+		$current_image = imagecreatefrompng($uploaded_file) or $error = true;
+		if ($error === false) $new_image = imagecreatetruecolor($new_width, $new_height) or $error = true;
+		if ($error === false) imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
+		if ($error === false) imagepng($new_image, $file, $compressPNG) or $error = $true;
+	} elseif($imageMIME=='image/webp') {
+		// image of type WebP
+		$current_image = imagecreatefromwebp($uploaded_file) or $error = true;
+		if ($error === false) $new_image = imagecreatetruecolor($new_width, $new_height) or $error = true;
+		if ($error === false) imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
+		if ($error === false) imagewebp($new_image, $file, $compression) or $error = $true;
 	}
 	if ($error === false) return true;
 	else return false;

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2654,7 +2654,7 @@ function validate_image($image, $savePath) {
 			//JPEG
 			$imgTmp = imagecreatefromjpeg($image);
 			if ($imgTmp !== false) {
-				$isImg = imagejpeg($imgTmp, $savePath, 100);
+				$isImg = imagejpeg($imgTmp, $savePath, 90);
 			}
 		break;
 		case 3:
@@ -2668,7 +2668,7 @@ function validate_image($image, $savePath) {
 			// WebP
 			$imgTmp = imagecreatefromwebp($image);
 			if ($imgTmp !== false) {
-				$isImg = imagewebp($imgTmp, $savePath, 100);
+				$isImg = imagewebp($imgTmp, $savePath, 90);
 			}
 		break;
 		default:

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2633,15 +2633,14 @@ function setReceiptTimestamp($offset = 0) {
  * @param ressource $image the image name, taken from the $_FILES array
  * @param string $savePath path to the saving location of the resulting image file
  * @return bool [false]
- * @return array [success status (true), mimetype]
+ * @return string [mimetype]
  */
 function validate_image($image, $savePath) {
 	// set the working variable for the file type check
 	$isImg = false;
 	$imgTmp = false;
-	$imageInfo = ["valid" => false, "mimetype" => false];
 	
-	// does the temporary file in itself exist?
+	// does the temporary image file in vain in itself exist?
 	if (!file_exists($image)) return false;
 	// what is the mimetype of the file?
 	$mimeImg = mime_content_type($image);
@@ -2684,8 +2683,7 @@ function validate_image($image, $savePath) {
 			$isImg = false;
 	}
 	if ($isImg === false) return false;
-	$imageInfo = ["valid" => $isImg, "mimeType" => $mimeImg];
-	return $imageInfo;
+	return $mimeImg;
 }
 
 

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -2629,6 +2629,8 @@ function setReceiptTimestamp($offset = 0) {
 function validate_image($image, $savePath) {
 	// set the working variable for the file type check
 	$isImg = false;
+	$imgTmp = false;
+	$imageInfo = ["valid" => false, "mimetype" => false];
 	
 	// does the file in itself exist?
 	if (!file_exists($image)) return false;

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -1537,7 +1537,7 @@ function resize_image($uploaded_file, $file, $new_width, $new_height, $compressi
 			$current_image = imagecreatefromwebp($uploaded_file) or $error = true;
 			if (empty($error)) $new_image = imagecreatetruecolor($new_width, $new_height) or $error = true;
 			if (empty($error)) imagecopyresampled($new_image, $current_image, 0, 0, 0, 0, $new_width, $new_height, $image_info[0], $image_info[1]) or $error = true;
-			if (empty($error)) imagewebp($new_image, $file) or $error = $true;
+			if (empty($error)) imagewebp($new_image, $file, $compression) or $error = $true;
 		}
 	}
 	if (empty($error)) return true;

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -16,7 +16,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		$img_tmp_name = uniqid(rand()).'.tmp';
 		$imgResized = false;
 		
-		$imageMime = validate_image($_FILES['probe']['tmp_name'], $uploaded_images_path.$img_tmp_name);
+		$imageMime = write_image($_FILES['probe']['tmp_name'], $uploaded_images_path.$img_tmp_name);
 		if (!file_exists($uploaded_images_path.$img_tmp_name))
 			$errors[] = 'upload_error';
 		if ($imageMime === false)

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -40,8 +40,9 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 					$new_height = $image_info[1];
 				}
 				for ($compression = 100; $compression > 1; $compression = $compression - 10) {
-					if (!resize_image($_FILES['probe']['tmp_name'], $uploaded_images_path.$img_tmp_name, $new_width, $new_height, $compression)) {
-						$file_size = $_FILES['probe']['size']; // @filesize($_FILES['probe']['tmp_name']);
+				clearstatcache();
+					if (!resize_image($uploaded_images_path.$img_tmp_name, $uploaded_images_path.$img_tmp_name, $new_width, $new_height, $compression)) {
+						$imageSize = filesize($uploaded_images_path.$img_tmp_name);
 						break;
 					}
 					$file_size = @filesize($uploaded_images_path.$img_tmp_name);

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -88,8 +88,6 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 				$smarty->assign('image_downsized', true);
 				$smarty->assign('new_width', $new_width);
 				$smarty->assign('new_height', $new_height);
-			} else {
-				@move_uploaded_file($_FILES['probe']['tmp_name'], $uploaded_images_path.$filename) or $errors[] = 'upload_error';
 				$smarty->assign('new_filesize', number_format($imageSize / 1000, 0, ',', ''));
 			}
 		}

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -14,6 +14,8 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		unset($errors);
 		$user_id = (isset($_SESSION[$settings['session_prefix'].'user_id'])) ? intval($_SESSION[$settings['session_prefix'].'user_id']) : NULL;
 		$img_tmp_name = uniqid(rand()).'.tmp';
+		$imgResized = false;
+		
 		$imageTemp = validate_image($_FILES['probe']['tmp_name'], $uploaded_images_path.$img_tmp_name);
 		if (!file_exists($uploaded_images_path.$img_tmp_name))
 			$errors[] = 'upload_error';
@@ -43,6 +45,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 				clearstatcache();
 					if (!resize_image($uploaded_images_path.$img_tmp_name, $uploaded_images_path.$img_tmp_name, $new_width, $new_height, $compression)) {
 						$imageSize = filesize($uploaded_images_path.$img_tmp_name);
+						$imgResized = false;
 						break;
 					}
 					$imageSize = @filesize($uploaded_images_path.$img_tmp_name);
@@ -85,7 +88,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 			}
 			if (isset($img_tmp_name)) {
 				@rename($uploaded_images_path.$img_tmp_name, $uploaded_images_path.$filename) or $errors[] = 'upload_error';
-				$smarty->assign('image_downsized', true);
+				$smarty->assign('image_downsized', $imgResized);
 				$smarty->assign('new_width', $new_width);
 				$smarty->assign('new_height', $new_height);
 				$smarty->assign('new_filesize', number_format($imageSize / 1000, 0, ',', ''));

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -41,8 +41,8 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 					$new_width = $image_info[0];
 					$new_height = $image_info[1];
 				}
-				clearstatcache();
 				for ($compression = 95; $compression > 50; $compression = $compression - 5) {
+					clearstatcache();
 					if (!resize_image($uploaded_images_path.$img_tmp_name, $uploaded_images_path.$img_tmp_name, $new_width, $new_height, $compression)) {
 						$imageSize = filesize($uploaded_images_path.$img_tmp_name);
 						$imgResized = false;

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -16,6 +16,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		$image_info = getimagesize($_FILES['probe']['tmp_name']);
 		$imageMIME = mime_content_type($_FILES['probe']['tmp_name']);
 		if (!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png', 'image/webp']))
+		$img_tmp_name = uniqid(rand()).'.tmp';
 			$errors[] = 'invalid_file_format';
 
 		if (empty($errors)) {
@@ -35,7 +36,6 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 					$new_width = $width;
 					$new_height = $height;
 				}
-				$img_tmp_name = uniqid(rand()).'.tmp';
 				for ($compression = 100; $compression > 1; $compression = $compression - 10) {
 					if (!resize_image($_FILES['probe']['tmp_name'], $uploaded_images_path.$img_tmp_name, $new_width, $new_height, $compression)) {
 						$file_size = $_FILES['probe']['size']; // @filesize($_FILES['probe']['tmp_name']);

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -45,8 +45,8 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 						$imageSize = filesize($uploaded_images_path.$img_tmp_name);
 						break;
 					}
-					if ($imageMIME != 'image/jpeg' && $file_size > $settings['upload_max_img_size'] * 1000) break;
 					$imageSize = @filesize($uploaded_images_path.$img_tmp_name);
+					if ($imageTemp['mimeType'] != 'image/jpeg' && $file_size > $settings['upload_max_img_size'] * 1000) break;
 					if ($imageSize <= $settings['upload_max_img_size'] * 1000) break;
 				}
 				if ($imageSize > $settings['upload_max_img_size'] * 1000) {
@@ -69,7 +69,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 
 		if (empty($errors)) {
 			$filename = gmdate("YmdHis").uniqid('');
-			switch($imageMIME) {
+			switch($imageTemp['mimeType']) {
 				case 'image/gif':
 					$filename .= '.gif';
 				break;

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -20,10 +20,10 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		if ($imageTemp === false)
 			$errors[] = 'invalid_file_format';
 
-		if (empty($errors)) {
 			if ($_FILES['probe']['size'] > $settings['upload_max_img_size'] * 1000 || $image_info[0] > $settings['upload_max_img_width'] || $image_info[1] > $settings['upload_max_img_height']) {
 				$width = $image_info[0];
 				$height = $image_info[1];
+		if (empty($errors) && $imageTemp['valid'] === true) {
 				// resize if too large:
 				if ($width > $settings['upload_max_img_width'] || $height > $settings['upload_max_img_height']) {
 					if ($width >= $height) {

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -41,8 +41,8 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 					$new_width = $image_info[0];
 					$new_height = $image_info[1];
 				}
-				for ($compression = 100; $compression > 1; $compression = $compression - 10) {
 				clearstatcache();
+				for ($compression = 95; $compression > 50; $compression = $compression - 5) {
 					if (!resize_image($uploaded_images_path.$img_tmp_name, $uploaded_images_path.$img_tmp_name, $new_width, $new_height, $compression)) {
 						$imageSize = filesize($uploaded_images_path.$img_tmp_name);
 						$imgResized = false;

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -158,7 +158,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 	elseif (empty($_GET['browse_images'])) {
 		$smarty->assign('form',true);
 	}
-	if (empty($errors) && isset($_FILES['probe']['error'])) {
+	if (count($errors) == 0 && isset($_FILES['probe']['error'])) {
 		$smarty->assign('server_max_filesize', ini_get('upload_max_filesize'));
 		$errors[] = 'upload_error_2';
 		$smarty->assign('errors', $errors);

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -45,14 +45,14 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 						$imageSize = filesize($uploaded_images_path.$img_tmp_name);
 						break;
 					}
-					$file_size = @filesize($uploaded_images_path.$img_tmp_name);
 					if ($imageMIME != 'image/jpeg' && $file_size > $settings['upload_max_img_size'] * 1000) break;
-					if ($file_size <= $settings['upload_max_img_size'] * 1000) break;
+					$imageSize = @filesize($uploaded_images_path.$img_tmp_name);
+					if ($imageSize <= $settings['upload_max_img_size'] * 1000) break;
 				}
-				if ($file_size > $settings['upload_max_img_size'] * 1000) {
+				if ($imageSize > $settings['upload_max_img_size'] * 1000) {
 					$smarty->assign('width', $image_info[0]);
 					$smarty->assign('height', $image_info[1]);
-					$smarty->assign('filesize', number_format($_FILES['probe']['size'] / 1000, 0, ',', ''));
+					$smarty->assign('filesize', number_format($imageSize / 1000, 0, ',', ''));
 					$smarty->assign('max_width', $settings['upload_max_img_width']);
 					$smarty->assign('max_height', $settings['upload_max_img_height']);
 					$smarty->assign('max_filesize', $settings['upload_max_img_size']);
@@ -88,9 +88,9 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 				$smarty->assign('image_downsized', true);
 				$smarty->assign('new_width', $new_width);
 				$smarty->assign('new_height', $new_height);
-				$smarty->assign('new_filesize', number_format($file_size / 1000, 0, ',', ''));
 			} else {
 				@move_uploaded_file($_FILES['probe']['tmp_name'], $uploaded_images_path.$filename) or $errors[] = 'upload_error';
+				$smarty->assign('new_filesize', number_format($imageSize / 1000, 0, ',', ''));
 			}
 		}
 		if (empty($errors)) {

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -16,13 +16,13 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		$img_tmp_name = uniqid(rand()).'.tmp';
 		$imgResized = false;
 		
-		$imageTemp = validate_image($_FILES['probe']['tmp_name'], $uploaded_images_path.$img_tmp_name);
+		$imageMime = validate_image($_FILES['probe']['tmp_name'], $uploaded_images_path.$img_tmp_name);
 		if (!file_exists($uploaded_images_path.$img_tmp_name))
 			$errors[] = 'upload_error';
-		if ($imageTemp === false)
+		if ($imageMime === false)
 			$errors[] = 'invalid_file_format';
 
-		if (count($errors) == 0 && $imageTemp['valid'] === true) {
+		if (count($errors) == 0) {
 			clearstatcache();
 			$image_info = getimagesize($uploaded_images_path.$img_tmp_name);
 			$imageSize = @filesize($uploaded_images_path.$img_tmp_name);
@@ -71,7 +71,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		
 		if (count($errors) == 0) {
 			$filename = gmdate("YmdHis").uniqid('');
-			switch($imageTemp['mimeType']) {
+			switch($imageMime) {
 				case 'image/gif':
 					$filename .= '.gif';
 				break;

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -22,7 +22,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		if ($imageMime === false)
 			$errors[] = 'invalid_file_format';
 
-		if (count($errors) == 0) {
+		if (empty($errors)) {
 			clearstatcache();
 			$image_info = getimagesize($uploaded_images_path.$img_tmp_name);
 			$imageSize = @filesize($uploaded_images_path.$img_tmp_name);
@@ -60,7 +60,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 					$smarty->assign('max_filesize', $settings['upload_max_img_size']);
 					$errors[] = 'file_too_large';
 				}
-				if (count($errors) > 0) {
+				if (empty($errors)) {
 					if (file_exists($uploaded_images_path.$img_tmp_name)) {
 						@chmod($uploaded_images_path.$img_tmp_name, 0777);
 						@unlink($uploaded_images_path.$img_tmp_name);
@@ -69,7 +69,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 			}
 		}
 		
-		if (count($errors) == 0) {
+		if (empty($errors)) {
 			$filename = gmdate("YmdHis").uniqid('');
 			switch($imageMime) {
 				case 'image/gif':
@@ -93,7 +93,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 				$smarty->assign('new_filesize', number_format($imageSize / 1000, 0, ',', ''));
 			}
 		}
-		if (count($errors) == 0) {
+		if (empty($errors)) {
 			@chmod($uploaded_images_path.$filename, 0644);
 			// $user_id can be NULL (see around line #15), because of that do not handle it with intval()
 			// see therefore variable definition of $user_id around line 15 of this script
@@ -158,7 +158,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 	elseif (empty($_GET['browse_images'])) {
 		$smarty->assign('form',true);
 	}
-	if (count($errors) == 0 && isset($_FILES['probe']['error'])) {
+	if (empty($errors) && isset($_FILES['probe']['error'])) {
 		$smarty->assign('server_max_filesize', ini_get('upload_max_filesize'));
 		$errors[] = 'upload_error_2';
 		$smarty->assign('errors', $errors);

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -20,25 +20,24 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		if ($imageTemp === false)
 			$errors[] = 'invalid_file_format';
 
-				$width = $image_info[0];
-				$height = $image_info[1];
 		if (empty($errors) && $imageTemp['valid'] === true) {
 			clearstatcache();
 			$image_info = getimagesize($uploaded_images_path.$img_tmp_name);
 			$imageSize = @filesize($uploaded_images_path.$img_tmp_name);
 			if ($imageSize > $settings['upload_max_img_size'] * 1000 || $image_info[0] > $settings['upload_max_img_width'] || $image_info[1] > $settings['upload_max_img_height']) {
 				// resize if too large:
-				if ($width > $settings['upload_max_img_width'] || $height > $settings['upload_max_img_height']) {
-					if ($width >= $height) {
+				$imgResized = true;
+				if ($image_info[0] > $settings['upload_max_img_width'] || $image_info[1] > $settings['upload_max_img_height']) {
+					if ($image_info[0] >= $image_info[1]) {
 						$new_width = $settings['upload_max_img_width'];
-						$new_height = intval($height*$new_width/$width);
+						$new_height = intval($image_info[1] * $new_width / $image_info[0]);
 					} else {
 						$new_height = $settings['upload_max_img_height'];
-						$new_width = intval($width*$new_height/$height);
+						$new_width = intval($image_info[0] * $new_height / $image_info[1]);
 					}
 				} else {
-					$new_width = $width;
-					$new_height = $height;
+					$new_width = $image_info[0];
+					$new_height = $image_info[1];
 				}
 				for ($compression = 100; $compression > 1; $compression = $compression - 10) {
 					if (!resize_image($_FILES['probe']['tmp_name'], $uploaded_images_path.$img_tmp_name, $new_width, $new_height, $compression)) {

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -20,10 +20,13 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		if ($imageTemp === false)
 			$errors[] = 'invalid_file_format';
 
-			if ($_FILES['probe']['size'] > $settings['upload_max_img_size'] * 1000 || $image_info[0] > $settings['upload_max_img_width'] || $image_info[1] > $settings['upload_max_img_height']) {
 				$width = $image_info[0];
 				$height = $image_info[1];
 		if (empty($errors) && $imageTemp['valid'] === true) {
+			clearstatcache();
+			$image_info = getimagesize($uploaded_images_path.$img_tmp_name);
+			$imageSize = @filesize($uploaded_images_path.$img_tmp_name);
+			if ($imageSize > $settings['upload_max_img_size'] * 1000 || $image_info[0] > $settings['upload_max_img_width'] || $image_info[1] > $settings['upload_max_img_height']) {
 				// resize if too large:
 				if ($width > $settings['upload_max_img_width'] || $height > $settings['upload_max_img_height']) {
 					if ($width >= $height) {

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -49,7 +49,6 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 						break;
 					}
 					$imageSize = @filesize($uploaded_images_path.$img_tmp_name);
-					if ($imageTemp['mimeType'] != 'image/jpeg' && $file_size > $settings['upload_max_img_size'] * 1000) break;
 					if ($imageSize <= $settings['upload_max_img_size'] * 1000) break;
 				}
 				if ($imageSize > $settings['upload_max_img_size'] * 1000) {

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -11,7 +11,7 @@ $images_per_page = 5;
 if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefix'].'user_type']) && $_SESSION[$settings['session_prefix'].'user_type'] > 0) || ($settings['upload_images'] == 2 && isset($_SESSION[$settings['session_prefix'].'user_id'])) || ($settings['upload_images'] == 3)) {
 	// upload:image:
 	if (isset($_FILES['probe']) && $_FILES['probe']['size'] != 0 && !$_FILES['probe']['error']) {
-		unset($errors);
+		$errors = [];
 		$user_id = (isset($_SESSION[$settings['session_prefix'].'user_id'])) ? intval($_SESSION[$settings['session_prefix'].'user_id']) : NULL;
 		$img_tmp_name = uniqid(rand()).'.tmp';
 		$imgResized = false;
@@ -22,7 +22,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 		if ($imageTemp === false)
 			$errors[] = 'invalid_file_format';
 
-		if (empty($errors) && $imageTemp['valid'] === true) {
+		if (count($errors) == 0 && $imageTemp['valid'] === true) {
 			clearstatcache();
 			$image_info = getimagesize($uploaded_images_path.$img_tmp_name);
 			$imageSize = @filesize($uploaded_images_path.$img_tmp_name);
@@ -61,7 +61,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 					$smarty->assign('max_filesize', $settings['upload_max_img_size']);
 					$errors[] = 'file_too_large';
 				}
-				if (isset($errors)) {
+				if (count($errors) > 0) {
 					if (file_exists($uploaded_images_path.$img_tmp_name)) {
 						@chmod($uploaded_images_path.$img_tmp_name, 0777);
 						@unlink($uploaded_images_path.$img_tmp_name);
@@ -69,8 +69,8 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 				}
 			}
 		}
-
-		if (empty($errors)) {
+		
+		if (count($errors) == 0) {
 			$filename = gmdate("YmdHis").uniqid('');
 			switch($imageTemp['mimeType']) {
 				case 'image/gif':
@@ -94,7 +94,7 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 				$smarty->assign('new_filesize', number_format($imageSize / 1000, 0, ',', ''));
 			}
 		}
-		if (empty($errors)) {
+		if (count($errors) == 0) {
 			@chmod($uploaded_images_path.$filename, 0644);
 			// $user_id can be NULL (see around line #15), because of that do not handle it with intval()
 			// see therefore variable definition of $user_id around line 15 of this script

--- a/includes/upload_image.inc.php
+++ b/includes/upload_image.inc.php
@@ -13,10 +13,11 @@ if (($settings['upload_images'] == 1 && isset($_SESSION[$settings['session_prefi
 	if (isset($_FILES['probe']) && $_FILES['probe']['size'] != 0 && !$_FILES['probe']['error']) {
 		unset($errors);
 		$user_id = (isset($_SESSION[$settings['session_prefix'].'user_id'])) ? intval($_SESSION[$settings['session_prefix'].'user_id']) : NULL;
-		$image_info = getimagesize($_FILES['probe']['tmp_name']);
-		$imageMIME = mime_content_type($_FILES['probe']['tmp_name']);
-		if (!is_array($image_info) || !in_array($imageMIME, ['image/gif', 'image/jpeg', 'image/png', 'image/webp']))
 		$img_tmp_name = uniqid(rand()).'.tmp';
+		$imageTemp = validate_image($_FILES['probe']['tmp_name'], $uploaded_images_path.$img_tmp_name);
+		if (!file_exists($uploaded_images_path.$img_tmp_name))
+			$errors[] = 'upload_error';
+		if ($imageTemp === false)
 			$errors[] = 'invalid_file_format';
 
 		if (empty($errors)) {


### PR DESCRIPTION
Because of a report we have to enhance the validation of uploaded images in the upload process itself but also in the later output generation with uploaded images. The current code does not ensure, that uploaded images are really images and not non-image-files with image file extensions. Allowed are the file types GIF (`image/gif`), JPG (`image/jpeg`), PNG (`image/png`) and WebP (`image/webp`). All other file types should be rejected.

Because of this I propose a new function `is_valid_image_type` in which runs the following checks.

- Does the file under the provided path exist?
- Does the mime type is one of the allowed ~~file~~ types?
- Can PHP create a valid image of the same type from the provided file?

If all questions are answered with "yes", the funtion returns `true` but `false` otherwise.

The function needs a bit of further refinement.