### PR TITLE
Add elements for new contacting scheme settings to the user edit form in the admin area

### DIFF
--- a/includes/admin.inc.php
+++ b/includes/admin.inc.php
@@ -121,7 +121,12 @@ if (isset($_SESSION[$settings['session_prefix'].'user_id']) && isset($_SESSION[$
 		$edit_user_name = (!empty($_POST['edit_user_name'])) ? trim($_POST['edit_user_name']) : '';
 		$edit_user_type = intval($_POST['edit_user_type']);
 		$user_email = (!empty($_POST['edit_user_name'])) ? trim($_POST['user_email']) : '';
-		$email_contact = (isset($_POST['email_contact'])) ? 1 : 0;
+		if (isset($_POST['email_contact'])) 
+			$email_contact = intval($_POST['email_contact']);
+		else 
+			$email_contact = 0;
+		if ($email_contact < 0 || $email_contact > 2) 
+			$email_contact = 0;
 		$user_real_name = (!empty($_POST['edit_user_name'])) ? trim($_POST['user_real_name']) : '';
 		$user_birthday = (!empty($_POST['edit_user_name'])) ? trim($_POST['user_birthday']) : '';
 		$gender = (isset($_POST['user_gender'])) ? intval($_POST['user_gender']) : 0;

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -615,6 +615,16 @@
 <td><input type="text" size="40" name="user_email" value="{$user_email}" /></td>
 </tr>
 <tr>
+<td><strong>{#edit_user_contacting#}</strong></td>
+<td>
+ <ul>
+  <li><input id="email_contact_disabled" type="radio" name="email_contact" value="0"{if $email_contact=="0"} checked="checked"{/if} /><label for="email_contact_disabled">{#edit_user_contacting_disabled#}</label></li>
+  <li><input id="email_contact_registered" type="radio" name="email_contact" value="1"{if $email_contact=="1"} checked="checked"{/if} /><label for="email_contact_registered">{#edit_user_contacting_registered#}</label></li>
+  <li><input id="email_contact_public" type="radio" name="email_contact" value="2"{if $email_contact=="2"} checked="checked"{/if} /><label for="email_contact_public">{#edit_user_contacting_public#}</label></li>
+ </ul>
+</td>
+</tr>
+<tr>
 <td><strong>{#edit_user_hp#}</strong></td>
 <td><input type="text" size="40" name="user_hp" value="{$user_hp}" maxlength="{$settings.hp_maxlength}" /></td>
 </tr>


### PR DESCRIPTION
With version 20220508.1 (2.5.0) the contacting settings for the user account was changed from off/on (0/1) to contactible by all (2), only registered users (1) or only by administrators and moderators (0). In the edit form for ones own user settings the form elements for the changed behaviour was added but in the user edit form in the admin area this was forgotten.

This pull request adds the form elements and the code for processing the input to the admin area script and the template in the default theme.  