### PR TITLE
PHP 8.4 deprecation notice about nullable

### DIFF
--- a/modules/b8/b8.php
+++ b/modules/b8/b8.php
@@ -138,7 +138,7 @@ class b8
      * @param string The text to classify
      * @return mixed float The rating between 0 (ham) and 1 (spam) or an error code
      */
-    public function classify(string $text = null)
+    public function classify(?string $text = null)
     {
         // Let's first see if the user called the function correctly
         if ($text === null) {
@@ -341,7 +341,7 @@ class b8
      * @param string Either b8::SPAM or b8::HAM
      * @return mixed void or an error code
      */
-    public function learn(string $text = null, string $category = null)
+    public function learn(?string $text = null, ?string $category = null)
     {
         // Let's first see if the user called the function correctly
         if ($text === null) {
@@ -362,7 +362,7 @@ class b8
      * @param string Either b8::SPAM or b8::HAM
      * @return mixed void or an error code
      */
-    public function unlearn(string $text = null, string $category = null)
+    public function unlearn(?string $text = null, ?string $category = null)
     {
         // Let's first see if the user called the function correctly
         if ($text === null) {

--- a/modules/b8/lexer/standard.php
+++ b/modules/b8/lexer/standard.php
@@ -181,7 +181,7 @@ class standard
      * @param string $word_to_remove Word to remove from the processed string
      * @return void
      */
-    private function add_token(string $token, string $word_to_remove = null)
+    private function add_token(string $token, ?string $word_to_remove = null)
     {
         // Check the validity of the token
         if (! $this->is_valid($token)) {


### PR DESCRIPTION
- Explicit nullable type added to the function signatures of B8 functions to remove deprecation notices in PHP 8.4, see also https://gitlab.com/l3u/b8/-/issues?show=eyJpaWQiOiIzIiwiZnVsbF9wYXRoIjoibDN1L2I4IiwiaWQiOjE2NDAyMzYwMH0%3D