### PR TITLE
Fix youtube embedding

### DIFF
--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -665,7 +665,7 @@ function do_bbcode_media($action, $attributes, $content, $params, $node_object) 
 				if (!empty($videoMatches) && isset($mediaTypes[$videoMatches[1]]))
 					$media = "<video width=\"" . $videoWidth . "\" height=\"" . $videoHeight . "\" controls src=\"" . htmlspecialchars($videoMatches[0]) . "\" type=\"video/" . htmlspecialchars($mediaTypes[$videoMatches[1]]) . "\">Your browser does not support the video tag. Please visit <a href=\"" . htmlspecialchars($videoMatches[0]) . "\">" . htmlspecialchars($videoMatches[0]) . "</a>.</video>";
 				else
-					$media = "<iframe width=\"" . $videoWidth . "\" height=\"" . $videoHeight . "\" src=\"https://www.youtube.com/embed/" . htmlspecialchars($youtubeMatches[1]) . "\" frameborder=\"0\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen>Your browser does not support iframes. Please visit <a href=\"" . htmlspecialchars($youtubeMatches[0]) . "\">" . htmlspecialchars($youtubeMatches[0]) . "</a>.</iframe>";
+					$media = "<iframe width=\"" . $videoWidth . "\" height=\"" . $videoHeight . "\" src=\"https://www.youtube-nocookie.com/embed/" . htmlspecialchars($youtubeMatches[1]) . "\" frameborder=\"0\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen>Your browser does not support iframes. Please visit <a href=\"" . htmlspecialchars($youtubeMatches[0]) . "\">" . htmlspecialchars($youtubeMatches[0]) . "</a>.</iframe>";
 			break;
 		}
 		return $media;

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -641,7 +641,7 @@ function do_bbcode_media($action, $attributes, $content, $params, $node_object) 
 				preg_match($audioPattern, $content, $audioMatches);
 				if ($action == 'validate')
 					return !empty($audioMatches) && isset($mediaTypes[$audioMatches[1]]);
-				$media = "<audio controls src=\"" . htmlspecialchars($audioMatches[0]) . "\" type=\"audio/" . htmlspecialchars($mediaTypes[$audioMatches[1]]) . "\">Your browser does not support the audio tag. Please visit <a href=\"" . htmlspecialchars($audioMatches[0]) . "\">" . htmlspecialchars($audioMatches[0]) . "</a>.</audio>";
+				$media = '<audio controls src="' . htmlspecialchars($audioMatches[0]) . '" type="audio/' . htmlspecialchars($mediaTypes[$audioMatches[1]]) . '">Your browser does not support the audio tag. Please visit <a href="' . htmlspecialchars($audioMatches[0]) . '">' . htmlspecialchars($audioMatches[0]) . '</a>.</audio>';
 					
 			break;
 			
@@ -663,9 +663,9 @@ function do_bbcode_media($action, $attributes, $content, $params, $node_object) 
 					return !empty($videoMatches) && isset($mediaTypes[$videoMatches[1]]) || !empty($youtubeMatches);
 				
 				if (!empty($videoMatches) && isset($mediaTypes[$videoMatches[1]]))
-					$media = "<video width=\"" . $videoWidth . "\" height=\"" . $videoHeight . "\" controls src=\"" . htmlspecialchars($videoMatches[0]) . "\" type=\"video/" . htmlspecialchars($mediaTypes[$videoMatches[1]]) . "\">Your browser does not support the video tag. Please visit <a href=\"" . htmlspecialchars($videoMatches[0]) . "\">" . htmlspecialchars($videoMatches[0]) . "</a>.</video>";
+					$media = '<video width="' . $videoWidth . '" height="' . $videoHeight . '" controls src="' . htmlspecialchars($videoMatches[0]) . '" type="video/' . htmlspecialchars($mediaTypes[$videoMatches[1]]) . '">Your browser does not support the video tag. Please visit <a href="' . htmlspecialchars($videoMatches[0]) . '">' . htmlspecialchars($videoMatches[0]) . '</a>.</video>';
 				else
-					$media = "<iframe width=\"" . $videoWidth . "\" height=\"" . $videoHeight . "\" src=\"https://www.youtube-nocookie.com/embed/" . htmlspecialchars($youtubeMatches[1]) . "\" frameborder=\"0\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen>Your browser does not support iframes. Please visit <a href=\"" . htmlspecialchars($youtubeMatches[0]) . "\">" . htmlspecialchars($youtubeMatches[0]) . "</a>.</iframe>";
+					$media = '<iframe width="' . $videoWidth . '" height="' . $videoHeight . '" src="https://www.youtube-nocookie.com/embed/' . htmlspecialchars($youtubeMatches[1]) . '" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen>Your browser does not support iframes. Please visit <a href="' . htmlspecialchars($youtubeMatches[0]) . '">' . htmlspecialchars($youtubeMatches[0]) . '</a>.</iframe>';
 			break;
 		}
 		return $media;

--- a/includes/functions.inc.php
+++ b/includes/functions.inc.php
@@ -665,7 +665,7 @@ function do_bbcode_media($action, $attributes, $content, $params, $node_object) 
 				if (!empty($videoMatches) && isset($mediaTypes[$videoMatches[1]]))
 					$media = "<video width=\"" . $videoWidth . "\" height=\"" . $videoHeight . "\" controls src=\"" . htmlspecialchars($videoMatches[0]) . "\" type=\"video/" . htmlspecialchars($mediaTypes[$videoMatches[1]]) . "\">Your browser does not support the video tag. Please visit <a href=\"" . htmlspecialchars($videoMatches[0]) . "\">" . htmlspecialchars($videoMatches[0]) . "</a>.</video>";
 				else
-					$media = "<iframe width=\"" . $videoWidth . "\" height=\"" . $videoHeight . "\" src=\"https://www.youtube.com/embed/" . htmlspecialchars($youtubeMatches[1]) . "\" frameborder=\"0\" allowfullscreen>Your browser does not support iframes. Please visit <a href=\"" . htmlspecialchars($youtubeMatches[0]) . "\">" . htmlspecialchars($youtubeMatches[0]) . "</a>.</iframe>";
+					$media = "<iframe width=\"" . $videoWidth . "\" height=\"" . $videoHeight . "\" src=\"https://www.youtube.com/embed/" . htmlspecialchars($youtubeMatches[1]) . "\" frameborder=\"0\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen>Your browser does not support iframes. Please visit <a href=\"" . htmlspecialchars($youtubeMatches[0]) . "\">" . htmlspecialchars($youtubeMatches[0]) . "</a>.</iframe>";
 			break;
 		}
 		return $media;


### PR DESCRIPTION
Embedding of Youtube videos in iframes was reported to be broken with error code 153 [in the project forum](https://mylittleforum.net/forum/index.php?id=19199) (f., postings in German language). An artcle on appuals.com offered several possible causes and solutions. I implemented the points 5 (change from youtube.com to youtube-nocookies.com) and 6 (add the attribute reffererpolicy with value `strict-origin-when-cross-origin`) to successfully solve the error.

Furthermore I replaced the double quotes to enclose strings for the output generation with single quotes in the function `do_bbcode_media`. This makes it obsolete to mask double quotes inside of the strings with baskslashes.