### PR TITLE
Remove the language strings enclosing single quotes

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -66,7 +66,7 @@ function my_parse_ini_file($path) {
 		$tmp = explode("=", $line, 2);
 		
 		$key = rtrim($tmp[0]);
-		$value = ltrim($tmp[1]);
+		$value = trim(ltrim($tmp[1]), "'");
 		if (preg_match("/^\".*\"$/", $value) || preg_match("/^'.*'$/", $value)) {
 			$value = mb_substr($value, 1, mb_strlen($value) - 2);
 		}


### PR DESCRIPTION
Since the language data is loaded past the Smarty engine, the quotation marks surrounding the strings must be removed manually. This is now done with the `trim` function.