### PR TITLE
Fixes of the upgrade process

### DIFF
--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1271,6 +1271,65 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				if (empty($update['errors'])) {
 					$update['status'][] = 'All original tables was renamed to *_old.';
 				}
+				
+				// rename the temporary tables to the original table names
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['banlists_table'] ."_tmp` TO `". $db_settings['banlists_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmarks_table'] ."_tmp` TO `". $db_settings['bookmarks_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmark_tags_table'] ."_tmp` TO `". $db_settings['bookmark_tags_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['category_table'] ."_tmp` TO `". $db_settings['category_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['entries_table'] ."_tmp` TO `". $db_settings['entries_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['entry_cache_table'] ."_tmp` TO `". $db_settings['entry_cache_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['entry_tags_table'] ."_tmp` TO `". $db_settings['entry_tags_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['login_control_table'] ."_tmp` TO `". $db_settings['login_control_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['pages_table'] ."_tmp` TO `". $db_settings['pages_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['read_status_table'] ."_tmp` TO `". $db_settings['read_status_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['settings_table'] ."_tmp` TO `". $db_settings['settings_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['smilies_table'] ."_tmp` TO `". $db_settings['smilies_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['subscriptions_table'] ."_tmp` TO `". $db_settings['subscriptions_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['tags_table'] ."_tmp` TO `". $db_settings['tags_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['temp_infos_table'] ."_tmp` TO `". $db_settings['temp_infos_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['userdata_table'] ."_tmp` TO `". $db_settings['userdata_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['userdata_cache_table'] ."_tmp` TO `". $db_settings['userdata_cache_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['useronline_table'] ."_tmp` TO `". $db_settings['useronline_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					$update['status'][] = 'All temporary tables was renamed to their original names.';
+				}
 			}
 			
 			// write the new version number to the database

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1211,6 +1211,68 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				mysqli_autocommit($connid, true);
 			}
 			
+			
+			if (empty($update['errors'])) {
+				// rename the original tables
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['banlists_table'] ."` TO `". $db_settings['banlists_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmarks_table'] ."` TO `". $db_settings['bookmarks_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmark_tags_table'] ."` TO `". $db_settings['bookmark_tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['category_table'] ."` TO `". $db_settings['category_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['entries_table'] ."` TO `". $db_settings['entries_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['entry_cache_table'] ."` TO `". $db_settings['entry_cache_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['entry_tags_table'] ."` TO `". $db_settings['entry_tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['login_control_table'] ."` TO `". $db_settings['login_control_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['pages_table'] ."` TO `". $db_settings['pages_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['read_status_table'] ."` TO `". $db_settings['read_status_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['settings_table'] ."` TO `". $db_settings['settings_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['smilies_table'] ."` TO `". $db_settings['smilies_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['subscriptions_table'] ."` TO `". $db_settings['subscriptions_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['tags_table'] ."` TO `". $db_settings['tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['temp_infos_table'] ."` TO `". $db_settings['temp_infos_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['userdata_table'] ."` TO `". $db_settings['userdata_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['userdata_cache_table'] ."` TO `". $db_settings['userdata_cache_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "RENAME `". $db_settings['useronline_table'] ."` TO `". $db_settings['useronline_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					$update['status'][] = 'All original tables was renamed to *_old.';
+				}
+			}
+			
 			// write the new version number to the database
 			if (empty($update['errors'])) {
 			$new_version_set = write_new_version_string_2_db($connid, $newVersion);

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1248,59 +1248,27 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 				
 				// delete all outdated *_old tables
+				$qDropOutdatedTables = "DROP TABLE
+					`". $db_settings['banlists_table'] ."_old`,
+					`". $db_settings['bookmark_table'] ."_old`,
+					`". $db_settings['bookmark_tags_table'] ."_old`,
+					`". $db_settings['category_table'] ."_old`,
+					`". $db_settings['forum_table'] ."_old`,
+					`". $db_settings['entry_cache_table'] ."_old`,
+					`". $db_settings['entry_tags_table'] ."_old`,
+					`". $db_settings['login_control_table'] ."_old`,
+					`". $db_settings['pages_table'] ."_old`,
+					`". $db_settings['read_status_table'] ."_old`,
+					`". $db_settings['settings_table'] ."_old`,
+					`". $db_settings['smilies_table'] ."_old`,
+					`". $db_settings['subscriptions_table'] ."_old`,
+					`". $db_settings['tags_table'] ."_old`,
+					`". $db_settings['temp_infos_table'] ."_old`,
+					`". $db_settings['userdata_table'] ."_old`,
+					`". $db_settings['userdata_cache_table'] ."_old`,
+					`". $db_settings['useronline_table'] ."_old`";
 				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['banlists_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['bookmark_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['bookmark_tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['category_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['entries_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['entry_cache_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['entry_tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['login_control_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['pages_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['read_status_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['settings_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['smilies_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['subscriptions_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['temp_infos_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['userdata_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['userdata_cache_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['useronline_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+					if (!mysqli_query($connid, $qDropOutdatedTables)) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 				}
 				if (empty($update['errors'])) {
 					$update['status'][] = 'All outdated tables was removed from the database.';

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1119,9 +1119,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			
 			
-			
 			/**
-			 * From here on everything can be done as a transaction in one step
+			 * Everything regarding new, changed or removed datasets can be done as a transaction in one step
 			 */
 			if (empty($update['errors'])) {
 				mysqli_autocommit($connid, false);

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1127,10 +1127,6 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				mysqli_autocommit($connid, false);
 				mysqli_begin_transaction($connid);
 				try {
-					// changes in the setting table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['settings_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
-					
 					$uaa = ($settings['user_area_public'] == 0) ? 2 : 1;
 					mysqli_query($connid, "INSERT INTO `" . $db_settings['settings_table'] . "` (`name`, `value`)
 					VALUES
@@ -1175,32 +1171,6 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					SELECT `id`, `spam`, 0 FROM `" . $db_settings['forum_table'] ."`;");
 					
 					
-					// changes in the user data table
-					/* is the following query really necessary? */
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "`
-					CHANGE `user_name` `user_name` VARCHAR(128) NOT NULL,
-					CHANGE `user_email` `user_email` VARCHAR(255) NOT NULL,
-					CHANGE `birthday` `birthday` DATE NULL DEFAULT NULL,
-					CHANGE `last_logout` `last_logout` TIMESTAMP NULL DEFAULT NULL,
-					CHANGE `registered` `registered` TIMESTAMP NULL DEFAULT NULL;");
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "`
-					CHANGE `user_name` `user_name` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;");
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "`
-					DROP INDEX `user_type`,
-					DROP INDEX `user_name`,
-					ADD KEY `key_user_type` (`user_type`),
-					ADD UNIQUE KEY `key_user_name` (`user_name`),
-					ADD UNIQUE KEY `key_user_email` (`user_email`);");
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "`
-					ADD `inactivity_notification` BOOLEAN NOT NULL DEFAULT FALSE,
-					ADD `browser_window_target` tinyint(4) NOT NULL DEFAULT '0' AFTER `user_lock`;");
-					
 					mysqli_query($connid, "UPDATE `" . $db_settings['userdata_table'] . "` SET
 					`birthday` = NULL
 					WHERE `birthday` <= STR_TO_DATE('1900-01-01','%Y-%d-%m');");
@@ -1211,39 +1181,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					
 					mysqli_query($connid, "UPDATE `" . $db_settings['userdata_table'] . "` SET
 					`registered` = NULL
-					WHERE `registered` <= STR_TO_DATE('1900-01-01','%Y-%d-%m');");
 					
-					
-					// changes in the user data cache table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_cache_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					
-					// changes in the forum/entries table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['forum_table'] . "`
-					DROP `spam`,
-					DROP `spam_check_status`;");
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['forum_table'] . "`
-					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
-					CHANGE `pid` `pid` int UNSIGNED NOT NULL DEFAULT '0',
-					CHANGE `tid` `tid` int UNSIGNED NOT NULL DEFAULT '0',
-					CHANGE `edited_by` `edited_by` int UNSIGNED NULL DEFAULT NULL,
-					CHANGE `user_id` `user_id` int UNSIGNED NULL DEFAULT '0',
-					CHANGE `category` `category` int UNSIGNED NOT NULL DEFAULT '0',
-					CHANGE `views` `views` int UNSIGNED NULL DEFAULT '0',
-					CHANGE `last_reply` `last_reply` TIMESTAMP NULL DEFAULT NULL,
-					CHANGE `edited` `edited` TIMESTAMP NULL DEFAULT NULL;");
-					
-					$rEN_exists = mysqli_query($connid, "SHOW COLUMNS FROM `". $db_settings['forum_table'] ."`
-					LIKE 'email_notification';");
-					if (mysqli_num_rows($rEN_exists) > 0) {
-						mysqli_query($connid, "ALTER TABLE `" . $db_settings['forum_table'] . "`
-						DROP `email_notification`;");
-					}
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['forum_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
 					
 					mysqli_query($connid, "UPDATE `" . $db_settings['forum_table'] . "` SET
 					`last_reply` = NULL
@@ -1252,117 +1190,6 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					mysqli_query($connid, "UPDATE `" . $db_settings['forum_table'] . "` SET
 					`edited` = NULL
 					WHERE `edited` <= STR_TO_DATE('1900-01-01','%Y-%d-%m');");
-					
-					
-					// changes in the banlist table
-					mysqli_query($connid, "RENAME TABLE `". $db_settings['banlists_table'] ."`
-					TO `". $db_settings['banlists_table'] ."_old`;");
-					
-					mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."` (`name` varchar(255) NOT NULL, `list` text NOT NULL, PRIMARY KEY (`name`)) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
-					
-					mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
-					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
-					FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'ips';");
-					
-					mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
-					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
-					FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'user_agents';");
-					
-					mysqli_query($connid, "INSERT INTO `". $db_settings['banlists_table'] ."`(`name`, `list`)
-					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
-					FROM `". $db_settings['banlists_table'] ."_old` WHERE `name` = 'words';");
-					
-					mysqli_query($connid, "DROP TABLE IF EXISTS `". $db_settings['banlists_table'] ."_old`;");
-					
-					
-					// changes in the bookmarks table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['bookmark_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['bookmark_table'] . "`
-					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
-					CHANGE `user_id` `user_id` int UNSIGNED NOT NULL,
-					CHANGE `posting_id` `posting_id` int UNSIGNED NOT NULL");
-					
-					
-					// changes in the bookmark tags table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['bookmark_tags_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					
-					// changes in the categories table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['category_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['category_table'] . "`
-					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT");
-					
-					
-					// changes in the entry cache table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['entry_cache_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					
-					// changes in the entry tags table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['entry_tags_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					
-					// changes in the login control table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['login_control_table'] . "`
-					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default '';");
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['login_control_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					
-					// changes in the pages table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['pages_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['pages_table'] . "`
-					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT");
-					
-					
-					// changes in the read entries table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['read_status_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					
-					// changes in the smilies table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['smilies_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['smilies_table'] . "`
-					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT");
-					
-					
-					// changes in the subscriptions table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['subscriptions_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					
-					// changes in the tags table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['tags_table'] . "`
-					CHANGE `tag` `tag` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
-					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT;");
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['tags_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
-					
-					
-					// changes in the temporary information table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['temp_infos_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
-					
-					
-					// changes in the user online table
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['useronline_table'] . "`
-					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default '',
-					CHANGE `user_id` `user_id` int UNSIGNED DEFAULT '0';");
-					
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['useronline_table'] . "`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;");
 					
 					mysqli_commit($connid);
 				} catch (mysqli_sql_exception $exception) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -322,6 +322,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
 				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+				} else {
+					$update['status'][] = 'Posting rating table for the Akismet filter created.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -335,6 +337,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
 				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+				} else {
+					$update['status'][] = 'Posting rating table for the Bayesian filter created.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -346,6 +350,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
 				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+				} else {
+					$update['status'][] = 'Wordlist table for the Bayesian filter created.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -361,6 +367,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
 				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+				} else {
+					$update['status'][] = 'Uploads table created.';
 				}
 			}
 			

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,6 +301,39 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
+			// changes in the entry tags table
+			$statusTestEntryTagsTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_tags_table'] ."_tmp` 
+					LIKE `". $db_settings['entry_tags_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestEntryTagsTable = false;
+				} else {
+					$update['status'] = 'Entry tags table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['entry_tags_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['entry_tags_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestEntryTagsTable = false;
+				} else {
+					$update['status'] = 'Data of entry tags table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['entry_tags_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestEntryTagsTable = false;
+				} else {
+					$update['status'] = 'Structure of entry tags table altered.';
+				}
+			}
+			
 			// changes in the login control table
 			$statusTestLoginControlTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1163,7 +1163,9 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				if (empty($update['errors'])) {
 					$update['status'][] = 'All original tables was renamed to *_old.';
 				}
-				
+			}
+			
+			if (empty($update['errors'])) {
 				// rename the temporary tables to the original table names
 				$qRenameTempTables = "RENAME TABLE
 					`". $db_settings['banlists_table'] ."_tmp` TO `". $db_settings['banlists_table'] ."`,
@@ -1190,7 +1192,9 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				if (empty($update['errors'])) {
 					$update['status'][] = 'All temporary tables was renamed to their corresponding original names.';
 				}
-				
+			}
+			
+			if (empty($update['errors'])) {
 				// delete all outdated *_old tables
 				$qDropOutdatedTables = "DROP TABLE
 					`". $db_settings['banlists_table'] ."_old`,

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -378,7 +378,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCreateTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."_tmp` (
 					`name` varchar(255) COLLATE utf8mb4_bin NOT NULL,
-					`list` text COLLATE=utf8mb4_general_ci NULL DEFAULT NULL,
+					`list` text COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
 					PRIMARY KEY (`name`)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
 				if (!mysqli_query($connid, $qCreateTable) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -642,8 +642,6 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 			}
 			if (empty($update['errors'])) {
-				// Do NOT drop columns span and spam_check_status at that time!
-				// The content of the columns is relevant for later operations.
 				$qAlterTable = "ALTER TABLE `". $db_settings['forum_table'] ."_tmp`
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
 					CHANGE `pid` `pid` int UNSIGNED NOT NULL DEFAULT '0',
@@ -653,7 +651,9 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CHANGE `category` `category` int UNSIGNED NOT NULL DEFAULT '0',
 					CHANGE `views` `views` int UNSIGNED NULL DEFAULT '0',
 					CHANGE `last_reply` `last_reply` TIMESTAMP NULL DEFAULT NULL,
-					CHANGE `edited` `edited` TIMESTAMP NULL DEFAULT NULL;";
+					CHANGE `edited` `edited` TIMESTAMP NULL DEFAULT NULL,
+					DROP `spam`,
+					DROP `spam_check_status`;";
 				if (!mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesTable = false;

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -380,8 +380,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					`name` varchar(255) COLLATE utf8mb4_bin NOT NULL,
 					`list` text COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
 					PRIMARY KEY (`name`)
-				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
 				if (!mysqli_query($connid, $qCreateTable) {
+				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1188,7 +1188,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					
 					mysqli_query($connid, "UPDATE `" . $db_settings['userdata_table'] . "_tmp` SET
 					`last_logout` = NULL
-					WHERE `last_logout` <= STR_TO_DATE('1900-01-01','%Y-%d-%m');");
+					WHERE `last_logout` <= STR_TO_DATE('1970-01-01','%Y-%d-%m');");
 					
 					mysqli_query($connid, "UPDATE `" . $db_settings['userdata_table'] . "_tmp` SET
 					`registered` = NULL

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1006,7 +1006,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataTable = false;
 				} else {
-					$update['status'][] = 'Data of userdata cache table copied.';
+					$update['status'][] = 'Data of userdata table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -1016,7 +1016,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataTable = false;
 				} else {
-					$update['status'][] = 'Structure of userdata cache table altered.';
+					$update['status'][] = 'Structure of userdata table altered.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -1037,7 +1037,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataTable = false;
 				} else {
-					$update['status'][] = 'Structure of userdata cache table altered.';
+					$update['status'][] = 'Structure of columns in userdata table altered.';
 				}
 			}
 			

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -302,10 +302,10 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// again before the section with the transaction begins!
 			mysqli_report(MYSQLI_REPORT_OFF);
 			// drop possibly existing new tables from previous tests with a pre release
-			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['akismet_rating_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['b8_rating_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['b8_wordlist_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['akismet_rating_table'] . "`")) $update['errors'][] = "Database error in line ". __LINE__ .":\n" . mysqli_error($connid);
+			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['b8_rating_table'] . "`")) $update['errors'][] = "Database error in line ". __LINE__ .":\n" . mysqli_error($connid);
+			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['b8_wordlist_table'] . "`")) $update['errors'][] = "Database error in line ". __LINE__ .":\n" . mysqli_error($connid);
+			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = "Database error in line ". __LINE__ .":\n" . mysqli_error($connid);
 			
 			
 			// change the existing tables
@@ -319,7 +319,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					PRIMARY KEY (`name`)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
 				if (!@mysqli_query($connid, $qCreateTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
 					$update['status'][] = 'Banlists table created.';
@@ -330,7 +330,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
 					FROM `". $db_settings['banlists_table'] ."` WHERE `name` = 'ips';";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
 					$update['status'][] = 'IP data of banlists table copied.';
@@ -341,7 +341,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
 					FROM `". $db_settings['banlists_table'] ."` WHERE `name` = 'user_agents';";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
 					$update['status'][] = 'User agents data of banlists table copied.';
@@ -352,7 +352,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
 					FROM `". $db_settings['banlists_table'] ."` WHERE `name` = 'words';";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
 					$update['status'][] = 'Bad words data of banlists table copied.';
@@ -365,7 +365,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmark_table'] ."_tmp`
 					LIKE `". $db_settings['bookmark_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
 					$update['status'][] = 'Bookmarks table copied.';
@@ -375,7 +375,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['bookmark_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['bookmark_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
 					$update['status'][] = 'Data of bookmarks table copied.';
@@ -388,7 +388,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CHANGE `user_id` `user_id` int UNSIGNED NOT NULL,
 					CHANGE `posting_id` `posting_id` int UNSIGNED NOT NULL";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
 					$update['status'][] = 'Structure of table and columns in bookmarks table altered.';
@@ -401,7 +401,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmark_tags_table'] ."_tmp`
 					LIKE `". $db_settings['bookmark_tags_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
 					$update['status'][] = 'Bookmark tags table copied.';
@@ -411,7 +411,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['bookmark_tags_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['bookmark_tags_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
 					$update['status'][] = 'Data of bookmark tags table copied.';
@@ -421,7 +421,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['bookmark_tags_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
 					$update['status'][] = 'Structure of bookmark tags table altered.';
@@ -434,7 +434,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['category_table'] ."_tmp`
 					LIKE `". $db_settings['category_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
 					$update['status'][] = 'Categories table copied.';
@@ -444,7 +444,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['category_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['category_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
 					$update['status'][] = 'Data of categories table copied.';
@@ -468,7 +468,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_cache_table'] ."_tmp`
 					LIKE `". $db_settings['entry_cache_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
 					$update['status'][] = 'Entries cache table copied.';
@@ -478,7 +478,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['entry_cache_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['entry_cache_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
 					$update['status'][] = 'Data of entries cache table copied.';
@@ -488,7 +488,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['entry_cache_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
 					$update['status'][] = 'Structure of entries cache table altered.';
@@ -501,7 +501,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_tags_table'] ."_tmp`
 					LIKE `". $db_settings['entry_tags_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
 					$update['status'][] = 'Entry tags table copied.';
@@ -511,7 +511,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['entry_tags_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['entry_tags_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
 					$update['status'][] = 'Data of entry tags table copied.';
@@ -521,7 +521,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['entry_tags_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
 					$update['status'][] = 'Structure of entry tags table altered.';
@@ -534,7 +534,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['forum_table'] ."_tmp`
 					LIKE `". $db_settings['forum_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestEntriesTable = false;
 				} else {
 					$update['status'][] = 'Forum entries table copied.';
@@ -544,7 +544,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['forum_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['forum_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestEntriesTable = false;
 				} else {
 					$update['status'][] = 'Data of forum entries table copied.';
@@ -565,7 +565,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					DROP `spam`,
 					DROP `spam_check_status`;";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestEntriesTable = false;
 				} else {
 					$update['status'][] = 'Structure of table and columns in login control table altered.';
@@ -578,12 +578,12 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					DROP `email_notification`";
 				$rEN_exists = @mysqli_query($connid, $qSearch4email_notification);
 				if ($rEN_exists === false) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 2) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 2) .":\n" . mysqli_error($connid);
 					$statusTestEntriesTable = false;
 				} else {
 					if (mysqli_num_rows($rEN_exists) > 0) {
 						if (!@mysqli_query($connid, $qAlterTable)) {
-							$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+							$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 							$statusTestEntriesTable = false;
 						} else {
 							$update['status'][] = 'Removed obsolete column email_notification from the forum entries table.';
@@ -598,7 +598,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['login_control_table'] ."_tmp`
 					LIKE `". $db_settings['login_control_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
 					$update['status'][] = 'Login control table copied.';
@@ -608,7 +608,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['login_control_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['login_control_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
 					$update['status'][] = 'Data of login control table copied.';
@@ -619,7 +619,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default ''";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
 					$update['status'][] = 'Structure of table and columns in login control table altered.';
@@ -632,7 +632,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['pages_table'] ."_tmp`
 					LIKE `". $db_settings['pages_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
 					$update['status'][] = 'Pages table copied.';
@@ -642,7 +642,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['pages_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['pages_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
 					$update['status'][] = 'Data of pages table copied.';
@@ -653,7 +653,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
 					$update['status'][] = 'Structure of table and columns in pages table altered.';
@@ -666,7 +666,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['read_status_table'] ."_tmp`
 					LIKE `". $db_settings['read_status_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
 					$update['status'][] = 'Read status table copied.';
@@ -676,7 +676,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['read_status_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['read_status_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
 					$update['status'][] = 'Data of read status table copied.';
@@ -686,7 +686,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['read_status_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
 					$update['status'][] = 'Structure of read status table altered.';
@@ -699,7 +699,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['settings_table'] ."_tmp`
 					LIKE `". $db_settings['settings_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
 					$update['status'][] = 'Settings table copied.';
@@ -709,7 +709,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['settings_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['settings_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
 					$update['status'][] = 'Data of settings table copied.';
@@ -719,7 +719,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['settings_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
 					$update['status'][] = 'Structure of settings table altered.';
@@ -732,7 +732,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['smilies_table'] ."_tmp`
 					LIKE `". $db_settings['smilies_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
 					$update['status'][] = 'Smilies table copied.';
@@ -742,7 +742,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['smilies_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['smilies_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
 					$update['status'][] = 'Data of smilies table copied.';
@@ -753,7 +753,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
 					$update['status'][] = 'Structure of table and columns in smilies table altered.';
@@ -766,7 +766,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['subscriptions_table'] ."_tmp`
 					LIKE `". $db_settings['subscriptions_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
 					$update['status'][] = 'Subscriptions table copied.';
@@ -776,7 +776,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['subscriptions_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['subscriptions_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
 					$update['status'][] = 'Data of subscriptions table copied.';
@@ -786,7 +786,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['subscriptions_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
 					$update['status'][] = 'Structure of subscriptions table altered.';
@@ -799,7 +799,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['tags_table'] ."_tmp`
 					LIKE `". $db_settings['tags_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
 					$update['status'][] = 'Tags table copied.';
@@ -809,7 +809,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['tags_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['tags_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
 					$update['status'][] = 'Data of tags table copied.';
@@ -821,7 +821,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CHANGE `tag` `tag` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
 					$update['status'][] = 'Structure of table and columns in tags table altered.';
@@ -834,7 +834,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['temp_infos_table'] ."_tmp`
 					LIKE `". $db_settings['temp_infos_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
 					$update['status'][] = 'Temporary information table copied.';
@@ -844,7 +844,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['temp_infos_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['temp_infos_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
 					$update['status'][] = 'Data of temporary information table copied.';
@@ -854,7 +854,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['temp_infos_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
 					$update['status'][] = 'Structure of temporary information table altered.';
@@ -867,7 +867,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_table'] ."_tmp`
 					LIKE `". $db_settings['userdata_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestUserdataTable = false;
 				} else {
 					$update['status'][] = 'Userdata table copied.';
@@ -877,7 +877,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['userdata_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['userdata_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestUserdataTable = false;
 				} else {
 					$update['status'][] = 'Data of userdata table copied.';
@@ -900,7 +900,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					ADD UNIQUE KEY `key_user_name` (`user_name`),
 					ADD UNIQUE KEY `key_user_email` (`user_email`);";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestUserdataTable = false;
 				} else {
 					$update['status'][] = 'Structure of table and columns in userdata table altered.';
@@ -913,7 +913,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_cache_table'] ."_tmp`
 					LIKE `". $db_settings['userdata_cache_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
 					$update['status'][] = 'Userdata cache table copied.';
@@ -923,7 +923,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['userdata_cache_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['userdata_cache_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
 					$update['status'][] = 'Data of userdata cache table copied.';
@@ -933,7 +933,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['userdata_cache_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
 					$update['status'][] = 'Structure of userdata cache table altered.';
@@ -946,7 +946,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['useronline_table'] ."_tmp`
 					LIKE `". $db_settings['useronline_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
 					$update['status'][] = 'User online table copied.';
@@ -956,7 +956,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['useronline_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['useronline_table'] ."`;";
 				if (!@mysqli_query($connid, $qCopyData)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
 					$update['status'][] = 'Data of user online table copied.';
@@ -968,7 +968,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default '',
 					CHANGE `user_id` `user_id` int UNSIGNED DEFAULT '0'";
 				if (!@mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
 					$update['status'][] = 'Structure of table and columns in user online table altered.';
@@ -985,7 +985,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					PRIMARY KEY (`eid`), KEY `akismet_spam` (`spam`), KEY spam_check_status (spam_check_status)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
 				if (!@mysqli_query($connid, $qCreateTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 				} else {
 					$update['status'][] = 'Posting rating table for the Akismet filter created.';
 				}
@@ -1000,7 +1000,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					KEY `B8_training_type` (`training_type`)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
 				if (!@mysqli_query($connid, $qCreateTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 				} else {
 					$update['status'][] = 'Posting rating table for the Bayesian filter created.';
 				}
@@ -1013,7 +1013,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					PRIMARY KEY (`token`)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
 				if (!@mysqli_query($connid, $qCreateTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 				} else {
 					$update['status'][] = 'Wordlist table for the Bayesian filter created.';
 				}
@@ -1030,7 +1030,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 						REFERENCES " . $db_settings['userdata_table'] . "_tmp(`user_id`) ON UPDATE CASCADE ON DELETE SET NULL
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
 				if (!@mysqli_query($connid, $qCreateTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 				} else {
 					$update['status'][] = 'Uploads table created.';
 				}
@@ -1158,7 +1158,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					`". $db_settings['userdata_cache_table'] ."` TO `". $db_settings['userdata_cache_table'] ."_old`,
 					`". $db_settings['useronline_table'] ."` TO `". $db_settings['useronline_table'] ."_old`";
 				if (!@mysqli_query($connid, $qRenameOriginalTables)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 				} else {
 					$update['status'][] = 'All original tables was renamed to *_old.';
 				}
@@ -1186,7 +1186,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					`". $db_settings['userdata_cache_table'] ."_tmp` TO `". $db_settings['userdata_cache_table'] ."`,
 					`". $db_settings['useronline_table'] ."_tmp` TO `". $db_settings['useronline_table'] ."`";
 				if (!@mysqli_query($connid, $qRenameTempTables)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "'Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 				} else {
 					$update['status'][] = 'All temporary tables was renamed to their corresponding original names.';
 				}
@@ -1214,7 +1214,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					`". $db_settings['userdata_cache_table'] ."_old`,
 					`". $db_settings['useronline_table'] ."_old`";
 				if (!mysqli_query($connid, $qDropOutdatedTables)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = "Database error in line ". (__LINE__ - 1) .":\n" . mysqli_error($connid);
 				} else {
 					$update['status'][] = 'All outdated tables was removed from the database.';
 				}

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1194,7 +1194,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					WHERE `registered` <= STR_TO_DATE('1970-01-01','%Y-%d-%m');");
 					
 					
-					// change datasets in the user entries table
+					// change datasets in the entries table
 					mysqli_query($connid, "UPDATE `" . $db_settings['forum_table'] . "_tmp` SET
 					`last_reply` = NULL
 					WHERE `last_reply` <= STR_TO_DATE('1900-01-01','%Y-%d-%m');");

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -914,6 +914,60 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 			}
 			
+			// changes in the user data table
+			$statusTestUserdataTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_table'] ."_tmp` 
+					LIKE `". $db_settings['userdata_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserdataTable = false;
+				} else {
+					$update['status'][] = 'Userdata table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['userdata_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['userdata_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserdataTable = false;
+				} else {
+					$update['status'][] = 'Data of userdata cache table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['userdata_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserdataTable = false;
+				} else {
+					$update['status'][] = 'Structure of userdata cache table altered.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['userdata_table'] ."_tmp`
+					CHANGE `user_name` `user_name` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+					CHANGE `user_email` `user_email` VARCHAR(255) NOT NULL,
+					CHANGE `birthday` `birthday` DATE NULL DEFAULT NULL,
+					CHANGE `last_logout` `last_logout` TIMESTAMP NULL DEFAULT NULL,
+					CHANGE `registered` `registered` TIMESTAMP NULL DEFAULT NULL,
+					ADD `inactivity_notification` BOOLEAN NOT NULL DEFAULT FALSE,
+					ADD `browser_window_target` tinyint(4) NOT NULL DEFAULT '0' AFTER `user_lock`,
+					DROP INDEX `user_type`,
+					DROP INDEX `user_name`,
+					ADD KEY `key_user_type` (`user_type`),
+					ADD UNIQUE KEY `key_user_name` (`user_name`),
+					ADD UNIQUE KEY `key_user_email` (`user_email`);";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserdataTable = false;
+				} else {
+					$update['status'][] = 'Structure of userdata cache table altered.';
+				}
+			}
+			
 			// changes in the user data cache table
 			$statusTestUserdataCacheTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -380,8 +380,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					`name` varchar(255) COLLATE utf8mb4_bin NOT NULL,
 					`list` text COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
 					PRIMARY KEY (`name`)
-				if (!mysqli_query($connid, $qCreateTable) {
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
+				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
@@ -427,7 +427,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmarks_table'] ."_tmp` 
 					LIKE `". $db_settings['bookmarks_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
@@ -472,7 +472,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmark_tags_table'] ."_tmp` 
 					LIKE `". $db_settings['bookmark_tags_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
@@ -505,7 +505,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['category_table'] ."_tmp` 
 					LIKE `". $db_settings['category_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
@@ -548,7 +548,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_cache_table'] ."_tmp` 
 					LIKE `". $db_settings['entry_cache_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
@@ -581,7 +581,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_tags_table'] ."_tmp` 
 					LIKE `". $db_settings['entry_tags_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
@@ -614,7 +614,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['forum_table'] ."_tmp` 
 					LIKE `". $db_settings['forum_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesTable = false;
 				} else {
@@ -687,7 +687,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['login_control_table'] ."_tmp` 
 					LIKE `". $db_settings['login_control_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
@@ -730,7 +730,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['pages_table'] ."_tmp` 
 					LIKE `". $db_settings['pages_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
@@ -773,7 +773,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['read_status_table'] ."_tmp` 
 					LIKE `". $db_settings['read_status_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
@@ -806,7 +806,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['settings_table'] ."_tmp` 
 					LIKE `". $db_settings['settings_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
@@ -839,7 +839,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['smilies_table'] ."_tmp` 
 					LIKE `". $db_settings['smilies_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
@@ -882,7 +882,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['subscriptions_table'] ."_tmp` 
 					LIKE `". $db_settings['subscriptions_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
@@ -915,7 +915,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['tags_table'] ."_tmp` 
 					LIKE `". $db_settings['tags_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
@@ -959,7 +959,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['temp_infos_table'] ."_tmp` 
 					LIKE `". $db_settings['temp_infos_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
@@ -992,7 +992,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_table'] ."_tmp` 
 					LIKE `". $db_settings['userdata_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataTable = false;
 				} else {
@@ -1046,7 +1046,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_cache_table'] ."_tmp` 
 					LIKE `". $db_settings['userdata_cache_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
@@ -1079,7 +1079,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['useronline_table'] ."_tmp` 
 					LIKE `". $db_settings['useronline_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -300,6 +300,40 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['b8_wordlist_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
+			
+			// changes in the subscriptions table
+			$statusTestSubscriptionsTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['subscriptions_table'] ."_tmp` 
+					LIKE `". $db_settings['subscriptions_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestSubscriptionsTable = false;
+				} else {
+					$update['status'] = 'Subscriptions table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['subscriptions_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['subscriptions_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestSubscriptionsTable = false;
+				} else {
+					$update['status'] = 'Data of subscriptions table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['subscriptions_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestSubscriptionsTable = false;
+				} else {
+					$update['status'] = 'Structure of subscriptions table altered.';
+				}
+			}
+			
 			// changes of the tags table
 			$statusTestTagsTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1194,59 +1194,27 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			
 			if (empty($update['errors'])) {
 				// rename the original tables
+				$qRenameOriginalTables = "RENAME TABLE
+					`". $db_settings['banlists_table'] ."` TO `". $db_settings['banlists_table'] ."_old`,
+					`". $db_settings['bookmark_table'] ."` TO `". $db_settings['bookmark_table'] ."_old`,
+					`". $db_settings['bookmark_tags_table'] ."` TO `". $db_settings['bookmark_tags_table'] ."_old`,
+					`". $db_settings['category_table'] ."` TO `". $db_settings['category_table'] ."_old`,
+					`". $db_settings['forum_table'] ."` TO `". $db_settings['forum_table'] ."_old`,
+					`". $db_settings['entry_cache_table'] ."` TO `". $db_settings['entry_cache_table'] ."_old`,
+					`". $db_settings['entry_tags_table'] ."` TO `". $db_settings['entry_tags_table'] ."_old`,
+					`". $db_settings['login_control_table'] ."` TO `". $db_settings['login_control_table'] ."_old`,
+					`". $db_settings['pages_table'] ."` TO `". $db_settings['pages_table'] ."_old`,
+					`". $db_settings['read_status_table'] ."` TO `". $db_settings['read_status_table'] ."_old`,
+					`". $db_settings['settings_table'] ."` TO `". $db_settings['settings_table'] ."_old`,
+					`". $db_settings['smilies_table'] ."` TO `". $db_settings['smilies_table'] ."_old`,
+					`". $db_settings['subscriptions_table'] ."` TO `". $db_settings['subscriptions_table'] ."_old`,
+					`". $db_settings['tags_table'] ."` TO `". $db_settings['tags_table'] ."_old`,
+					`". $db_settings['temp_infos_table'] ."` TO `". $db_settings['temp_infos_table'] ."_old`,
+					`". $db_settings['userdata_table'] ."` TO `". $db_settings['userdata_table'] ."_old`,
+					`". $db_settings['userdata_cache_table'] ."` TO `". $db_settings['userdata_cache_table'] ."_old`,
+					`". $db_settings['useronline_table'] ."` TO `". $db_settings['useronline_table'] ."_old`";
 				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['banlists_table'] ."` TO `". $db_settings['banlists_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmark_table'] ."` TO `". $db_settings['bookmark_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmark_tags_table'] ."` TO `". $db_settings['bookmark_tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['category_table'] ."` TO `". $db_settings['category_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['entries_table'] ."` TO `". $db_settings['entries_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['entry_cache_table'] ."` TO `". $db_settings['entry_cache_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['entry_tags_table'] ."` TO `". $db_settings['entry_tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['login_control_table'] ."` TO `". $db_settings['login_control_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['pages_table'] ."` TO `". $db_settings['pages_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['read_status_table'] ."` TO `". $db_settings['read_status_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['settings_table'] ."` TO `". $db_settings['settings_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['smilies_table'] ."` TO `". $db_settings['smilies_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['subscriptions_table'] ."` TO `". $db_settings['subscriptions_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['tags_table'] ."` TO `". $db_settings['tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['temp_infos_table'] ."` TO `". $db_settings['temp_infos_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['userdata_table'] ."` TO `". $db_settings['userdata_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['userdata_cache_table'] ."` TO `". $db_settings['userdata_cache_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['useronline_table'] ."` TO `". $db_settings['useronline_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+					if (!mysqli_query($connid, $qRenameOriginalTables)) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 				}
 				if (empty($update['errors'])) {
 					$update['status'][] = 'All original tables was renamed to *_old.';

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -376,16 +376,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['bookmark_table'] ."_tmp`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestBookmarksTable = false;
-				} else {
-					$update['status'][] = 'Structure of bookmarks table altered.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['bookmark_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
 					CHANGE `user_id` `user_id` int UNSIGNED NOT NULL,
 					CHANGE `posting_id` `posting_id` int UNSIGNED NOT NULL";
@@ -393,7 +384,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
-					$update['status'][] = 'Structure of columns in bookmarks table altered.';
+					$update['status'][] = 'Structure of table and columns in bookmarks table altered.';
 				}
 			}
 			
@@ -454,22 +445,13 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['category_table'] ."_tmp`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestCategoriesTable = false;
-				} else {
-					$update['status'][] = 'Structure of categories table altered.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['category_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
 				if (!mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
-					$update['status'][] = 'Structure of columns in categories table altered.';
+					$update['status'][] = 'Structure of table and columns in categories table altered.';
 				}
 			}
 			
@@ -563,16 +545,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['forum_table'] ."_tmp`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestEntriesTable = false;
-				} else {
-					$update['status'][] = 'Structure of forum entries table altered.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['forum_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
 					CHANGE `pid` `pid` int UNSIGNED NOT NULL DEFAULT '0',
 					CHANGE `tid` `tid` int UNSIGNED NOT NULL DEFAULT '0',
@@ -588,7 +561,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesTable = false;
 				} else {
-					$update['status'][] = 'Structure of columns in login control table altered.';
+					$update['status'][] = 'Structure of table and columns in login control table altered.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -636,22 +609,13 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['login_control_table'] ."_tmp`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestLoginControlTable = false;
-				} else {
-					$update['status'][] = 'Structure of login control table altered.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['login_control_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default ''";
 				if (!mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
-					$update['status'][] = 'Structure of columns in login control table altered.';
+					$update['status'][] = 'Structure of table and columns in login control table altered.';
 				}
 			}
 			
@@ -679,22 +643,13 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['pages_table'] ."_tmp`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestPagesTable = false;
-				} else {
-					$update['status'][] = 'Structure of pages table altered.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['pages_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
 				if (!mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
-					$update['status'][] = 'Structure of columns in pages table altered.';
+					$update['status'][] = 'Structure of table and columns in pages table altered.';
 				}
 			}
 			
@@ -788,22 +743,13 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['smilies_table'] ."_tmp`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestSmiliesTable = false;
-				} else {
-					$update['status'][] = 'Structure of smilies table altered.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['smilies_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
 				if (!mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
-					$update['status'][] = 'Structure of columns in smilies table altered.';
+					$update['status'][] = 'Structure of table and columns in smilies table altered.';
 				}
 			}
 			
@@ -864,23 +810,14 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['tags_table'] ."_tmp`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
-				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestTagsTable = false;
-				} else {
-					$update['status'][] = 'Structure of tags table altered.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['tags_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
 					CHANGE `tag` `tag` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
 				if (!mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
-					$update['status'][] = 'Structure of columns in tags table altered.';
+					$update['status'][] = 'Structure of table and columns in tags table altered.';
 				}
 			}
 			
@@ -941,16 +878,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['userdata_table'] ."_tmp`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
-				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestUserdataTable = false;
-				} else {
-					$update['status'][] = 'Structure of userdata table altered.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['userdata_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
 					CHANGE `user_id` `user_id` int UNSIGNED NOT NULL AUTO_INCREMENT,
 					CHANGE `user_name` `user_name` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
 					CHANGE `user_email` `user_email` VARCHAR(255) NOT NULL,
@@ -968,7 +896,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataTable = false;
 				} else {
-					$update['status'][] = 'Structure of columns in userdata table altered.';
+					$update['status'][] = 'Structure of table and columns in userdata table altered.';
 				}
 			}
 			
@@ -1029,23 +957,14 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['useronline_table'] ."_tmp`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestUserOnlineTable = false;
-				} else {
-					$update['status'][] = 'Structure of user online table altered.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['useronline_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default '',
 					CHANGE `user_id` `user_id` int UNSIGNED DEFAULT '0'";
 				if (!mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
-					$update['status'][] = 'Structure of columns in user online table altered.';
+					$update['status'][] = 'Structure of table and columns in user online table altered.';
 				}
 			}
 			

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1192,6 +1192,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					
 					mysqli_query($connid, "UPDATE `" . $db_settings['userdata_table'] . "_tmp` SET
 					`registered` = NULL
+					WHERE `registered` <= STR_TO_DATE('1970-01-01','%Y-%d-%m');");
 					
 					
 					// change datasets in the user entries table

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -373,7 +373,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
-					$update['status'] = 'Structure of tags table altered.';
+					$update['status'] = 'Structure of temporary information table altered.';
 				}
 			}
 			

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,6 +301,49 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
+			// changes in the categories table
+			$statusTestCategoriesTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['category_table'] ."_tmp` 
+					LIKE `". $db_settings['category_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestCategoriesTable = false;
+				} else {
+					$update['status'] = 'Categories table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['category_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['category_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestCategoriesTable = false;
+				} else {
+					$update['status'] = 'Data of categories table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['category_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestCategoriesTable = false;
+				} else {
+					$update['status'] = 'Structure of categories table altered.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['category_table'] ."_tmp`
+					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestCategoriesTable = false;
+				} else {
+					$update['status'] = 'Structure of columns in categories table altered.';
+				}
+			}
+			
 			// changes in the entry cache table
 			$statusTestEntriesCacheTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,6 +301,39 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
+			// changes in the bookmark tags table
+			$statusTestBookmarkTagsTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmark_tags_table'] ."_tmp` 
+					LIKE `". $db_settings['bookmark_tags_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestBookmarkTagsTable = false;
+				} else {
+					$update['status'] = 'Bookmark tags table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['bookmark_tags_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['bookmark_tags_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestBookmarkTagsTable = false;
+				} else {
+					$update['status'] = 'Data of bookmark tags table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['bookmark_tags_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestBookmarkTagsTable = false;
+				} else {
+					$update['status'] = 'Structure of bookmark tags table altered.';
+				}
+			}
+			
 			// changes in the categories table
 			$statusTestCategoriesTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,6 +301,49 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
+			// changes in the pages table
+			$statusTestPagesTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['pages_table'] ."_tmp` 
+					LIKE `". $db_settings['pages_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestPagesTable = false;
+				} else {
+					$update['status'] = 'Pages table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['pages_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['pages_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestPagesTable = false;
+				} else {
+					$update['status'] = 'Data of pages table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['pages_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestPagesTable = false;
+				} else {
+					$update['status'] = 'Structure of pages table altered.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['pages_table'] ."_tmp`
+					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestPagesTable = false;
+				} else {
+					$update['status'] = 'Structure of columns in pages table altered.';
+				}
+			}
+			
 			// changes in the read entries table
 			$statusTestReadStatusTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,6 +301,55 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
+			// changes in the banlist table
+			$statusTestBanlistsTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."_tmp` (
+					`name` varchar(255) COLLATE utf8mb4_bin NOT NULL,
+					`list` text COLLATE=utf8mb4_general_ci NULL DEFAULT NULL,
+					PRIMARY KEY (`name`)
+				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestBanlistsTable = false;
+				} else {
+					$update['status'] = 'Banlists table created.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT INTO `". $db_settings['banlists_table'] ."_tmp`
+					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+					FROM `". $db_settings['banlists_table'] ."` WHERE `name` = 'ips';";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestBanlistsTable = false;
+				} else {
+					$update['status'] = 'IP data of banlists table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT INTO `". $db_settings['banlists_table'] ."_tmp`
+					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+					FROM `". $db_settings['banlists_table'] ."` WHERE `name` = 'user_agents';";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestBanlistsTable = false;
+				} else {
+					$update['status'] = 'User agents data of banlists table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT INTO `". $db_settings['banlists_table'] ."_tmp`
+					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
+					FROM `". $db_settings['banlists_table'] ."` WHERE `name` = 'words';";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestBanlistsTable = false;
+				} else {
+					$update['status'] = 'Bad words data of banlists table copied.';
+				}
+			}
+			
 			// changes in the bookmarks table
 			$statusTestBookmarksTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1386,6 +1386,9 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				if (empty($update['errors'])) {
 					if (!mysqli_query($connid, "DROP `". $db_settings['useronline_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 				}
+				if (empty($update['errors'])) {
+					$update['status'][] = 'All outdated tables was removed from the database.';
+				}
 			}
 			
 			// write the new version number to the database

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,6 +301,49 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
+			// changes in the smilies table
+			$statusTestSmiliesTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['smilies_table'] ."_tmp` 
+					LIKE `". $db_settings['smilies_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestSmiliesTable = false;
+				} else {
+					$update['status'] = 'Smilies table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['smilies_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['smilies_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestSmiliesTable = false;
+				} else {
+					$update['status'] = 'Data of smilies table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['smilies_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestSmiliesTable = false;
+				} else {
+					$update['status'] = 'Structure of smilies table altered.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['smilies_table'] ."_tmp`
+					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestSmiliesTable = false;
+				} else {
+					$update['status'] = 'Structure of columns in smilies table altered.';
+				}
+			}
+			
 			// changes in the subscriptions table
 			$statusTestSubscriptionsTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -318,7 +318,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					`list` text COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
 					PRIMARY KEY (`name`)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-				if (!mysqli_query($connid, $qCreateTable)) {
+				if (!@mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
@@ -329,7 +329,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT INTO `". $db_settings['banlists_table'] ."_tmp`
 					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
 					FROM `". $db_settings['banlists_table'] ."` WHERE `name` = 'ips';";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
@@ -340,7 +340,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT INTO `". $db_settings['banlists_table'] ."_tmp`
 					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
 					FROM `". $db_settings['banlists_table'] ."` WHERE `name` = 'user_agents';";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
@@ -351,7 +351,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT INTO `". $db_settings['banlists_table'] ."_tmp`
 					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
 					FROM `". $db_settings['banlists_table'] ."` WHERE `name` = 'words';";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
@@ -364,7 +364,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmark_table'] ."_tmp`
 					LIKE `". $db_settings['bookmark_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
@@ -374,7 +374,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['bookmark_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['bookmark_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
@@ -387,7 +387,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
 					CHANGE `user_id` `user_id` int UNSIGNED NOT NULL,
 					CHANGE `posting_id` `posting_id` int UNSIGNED NOT NULL";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
@@ -400,7 +400,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmark_tags_table'] ."_tmp`
 					LIKE `". $db_settings['bookmark_tags_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
@@ -410,7 +410,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['bookmark_tags_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['bookmark_tags_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
@@ -420,7 +420,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['bookmark_tags_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
@@ -433,7 +433,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['category_table'] ."_tmp`
 					LIKE `". $db_settings['category_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
@@ -443,7 +443,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['category_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['category_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
@@ -454,7 +454,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['category_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
@@ -467,7 +467,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_cache_table'] ."_tmp`
 					LIKE `". $db_settings['entry_cache_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
@@ -477,7 +477,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['entry_cache_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['entry_cache_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
@@ -487,7 +487,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['entry_cache_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
@@ -500,7 +500,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_tags_table'] ."_tmp`
 					LIKE `". $db_settings['entry_tags_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
@@ -510,7 +510,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['entry_tags_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['entry_tags_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
@@ -520,7 +520,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['entry_tags_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
@@ -533,7 +533,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['forum_table'] ."_tmp`
 					LIKE `". $db_settings['forum_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesTable = false;
 				} else {
@@ -543,7 +543,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['forum_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['forum_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesTable = false;
 				} else {
@@ -564,7 +564,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CHANGE `edited` `edited` TIMESTAMP NULL DEFAULT NULL,
 					DROP `spam`,
 					DROP `spam_check_status`;";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesTable = false;
 				} else {
@@ -576,13 +576,13 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					LIKE 'email_notification';";
 				$qAlterTable = "ALTER TABLE `". $db_settings['forum_table'] ."_tmp`
 					DROP `email_notification`";
-				$rEN_exists = mysqli_query($connid, $qSearch4email_notification);
+				$rEN_exists = @mysqli_query($connid, $qSearch4email_notification);
 				if ($rEN_exists === false) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 2) .': ' . mysqli_error($connid);
 					$statusTestEntriesTable = false;
 				} else {
 					if (mysqli_num_rows($rEN_exists) > 0) {
-						if (!mysqli_query($connid, $qAlterTable)) {
+						if (!@mysqli_query($connid, $qAlterTable)) {
 							$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 							$statusTestEntriesTable = false;
 						} else {
@@ -597,7 +597,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['login_control_table'] ."_tmp`
 					LIKE `". $db_settings['login_control_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
@@ -607,7 +607,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['login_control_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['login_control_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
@@ -618,7 +618,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['login_control_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default ''";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
@@ -631,7 +631,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['pages_table'] ."_tmp`
 					LIKE `". $db_settings['pages_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
@@ -641,7 +641,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['pages_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['pages_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
@@ -652,7 +652,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['pages_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
@@ -665,7 +665,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['read_status_table'] ."_tmp`
 					LIKE `". $db_settings['read_status_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
@@ -675,7 +675,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['read_status_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['read_status_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
@@ -685,7 +685,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['read_status_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
@@ -698,7 +698,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['settings_table'] ."_tmp`
 					LIKE `". $db_settings['settings_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
@@ -708,7 +708,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['settings_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['settings_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
@@ -718,7 +718,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['settings_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
@@ -731,7 +731,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['smilies_table'] ."_tmp`
 					LIKE `". $db_settings['smilies_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
@@ -741,7 +741,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['smilies_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['smilies_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
@@ -752,7 +752,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['smilies_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
@@ -765,7 +765,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['subscriptions_table'] ."_tmp`
 					LIKE `". $db_settings['subscriptions_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
@@ -775,7 +775,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['subscriptions_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['subscriptions_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
@@ -785,7 +785,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['subscriptions_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
@@ -798,7 +798,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['tags_table'] ."_tmp`
 					LIKE `". $db_settings['tags_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
@@ -808,7 +808,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['tags_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['tags_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
@@ -820,7 +820,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin,
 					CHANGE `tag` `tag` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
@@ -833,7 +833,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['temp_infos_table'] ."_tmp`
 					LIKE `". $db_settings['temp_infos_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
@@ -843,7 +843,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['temp_infos_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['temp_infos_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
@@ -853,7 +853,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['temp_infos_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
@@ -866,7 +866,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_table'] ."_tmp`
 					LIKE `". $db_settings['userdata_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataTable = false;
 				} else {
@@ -876,7 +876,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['userdata_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['userdata_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataTable = false;
 				} else {
@@ -899,7 +899,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					ADD KEY `key_user_type` (`user_type`),
 					ADD UNIQUE KEY `key_user_name` (`user_name`),
 					ADD UNIQUE KEY `key_user_email` (`user_email`);";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataTable = false;
 				} else {
@@ -912,7 +912,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_cache_table'] ."_tmp`
 					LIKE `". $db_settings['userdata_cache_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
@@ -922,7 +922,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['userdata_cache_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['userdata_cache_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
@@ -932,7 +932,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['userdata_cache_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
@@ -945,7 +945,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['useronline_table'] ."_tmp`
 					LIKE `". $db_settings['useronline_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyTable)) {
+				if (!@mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
@@ -955,7 +955,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['useronline_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['useronline_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
+				if (!@mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
@@ -967,7 +967,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
 					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default '',
 					CHANGE `user_id` `user_id` int UNSIGNED DEFAULT '0'";
-				if (!mysqli_query($connid, $qAlterTable)) {
+				if (!@mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
@@ -984,7 +984,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					`spam_check_status` tinyint(1) NOT NULL DEFAULT '0',
 					PRIMARY KEY (`eid`), KEY `akismet_spam` (`spam`), KEY spam_check_status (spam_check_status)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-				if (!mysqli_query($connid, $qCreateTable)) {
+				if (!@mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 				} else {
 					$update['status'][] = 'Posting rating table for the Akismet filter created.';
@@ -999,7 +999,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					KEY `b8_spam` (`spam`),
 					KEY `B8_training_type` (`training_type`)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-				if (!mysqli_query($connid, $qCreateTable)) {
+				if (!@mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 				} else {
 					$update['status'][] = 'Posting rating table for the Bayesian filter created.';
@@ -1012,7 +1012,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					`count_spam` int unsigned default NULL,
 					PRIMARY KEY (`token`)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
-				if (!mysqli_query($connid, $qCreateTable)) {
+				if (!@mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 				} else {
 					$update['status'][] = 'Wordlist table for the Bayesian filter created.';
@@ -1029,7 +1029,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CONSTRAINT `smbl_". $table_prefix ."uploader` FOREIGN KEY `fk_uploader` (`uploader`)
 						REFERENCES " . $db_settings['userdata_table'] . "_tmp(`user_id`) ON UPDATE CASCADE ON DELETE SET NULL
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
-				if (!mysqli_query($connid, $qCreateTable)) {
+				if (!@mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 				} else {
 					$update['status'][] = 'Uploads table created.';

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -609,6 +609,79 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 			}
 			
+			// changes in the forum/entries table
+			$statusTestEntriesTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['forum_table'] ."_tmp` 
+					LIKE `". $db_settings['forum_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestEntriesTable = false;
+				} else {
+					$update['status'][] = 'Forum entries table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['forum_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['forum_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestEntriesTable = false;
+				} else {
+					$update['status'][] = 'Data of forum entries table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['forum_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestEntriesTable = false;
+				} else {
+					$update['status'][] = 'Structure of forum entries table altered.';
+				}
+			}
+			if (empty($update['errors'])) {
+				// Do NOT drop columns span and spam_check_status at that time!
+				// The content of the columns is relevant for later operations.
+				$qAlterTable = "ALTER TABLE `". $db_settings['forum_table'] ."_tmp`
+					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
+					CHANGE `pid` `pid` int UNSIGNED NOT NULL DEFAULT '0',
+					CHANGE `tid` `tid` int UNSIGNED NOT NULL DEFAULT '0',
+					CHANGE `edited_by` `edited_by` int UNSIGNED NULL DEFAULT NULL,
+					CHANGE `user_id` `user_id` int UNSIGNED NULL DEFAULT '0',
+					CHANGE `category` `category` int UNSIGNED NOT NULL DEFAULT '0',
+					CHANGE `views` `views` int UNSIGNED NULL DEFAULT '0',
+					CHANGE `last_reply` `last_reply` TIMESTAMP NULL DEFAULT NULL,
+					CHANGE `edited` `edited` TIMESTAMP NULL DEFAULT NULL;";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestEntriesTable = false;
+				} else {
+					$update['status'][] = 'Structure of columns in login control table altered.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qSearch4email_notification = "SHOW COLUMNS FROM `". $db_settings['forum_table'] ."`
+					LIKE 'email_notification';";
+				$qAlterTable = "ALTER TABLE `". $db_settings['forum_table'] ."_tmp`
+					DROP `email_notification`";
+				$rEN_exists = mysqli_query($connid, $qSearch4email_notification);
+				if ($rEN_exists === false) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 2) .': ' . mysqli_error($connid);
+					$statusTestEntriesTable = false;
+				} else {
+					if (mysqli_num_rows($rEN_exists) > 0) {
+						if (!mysqli_query($connid, $qAlterTable)) {
+							$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+							$statusTestEntriesTable = false;
+						} else {
+							$update['status'][] = 'Removed obsolete column email_notofications from the forum entries table.';
+						}
+					}
+				}
+			}
+			
 			// changes in the login control table
 			$statusTestLoginControlTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,6 +301,49 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
+			// changes in the login control table
+			$statusTestLoginControlTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['login_control_table'] ."_tmp` 
+					LIKE `". $db_settings['login_control_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestLoginControlTable = false;
+				} else {
+					$update['status'] = 'Login control table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['login_control_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['login_control_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestLoginControlTable = false;
+				} else {
+					$update['status'] = 'Data of login control table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['login_control_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestLoginControlTable = false;
+				} else {
+					$update['status'] = 'Structure of login control table altered.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['login_control_table'] ."_tmp`
+					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default ''";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestLoginControlTable = false;
+				} else {
+					$update['status'] = 'Structure of columns in login control table altered.';
+				}
+			}
+			
 			// changes in the pages table
 			$statusTestPagesTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1157,10 +1157,9 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					`". $db_settings['userdata_table'] ."` TO `". $db_settings['userdata_table'] ."_old`,
 					`". $db_settings['userdata_cache_table'] ."` TO `". $db_settings['userdata_cache_table'] ."_old`,
 					`". $db_settings['useronline_table'] ."` TO `". $db_settings['useronline_table'] ."_old`";
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, $qRenameOriginalTables)) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
+				if (!@mysqli_query($connid, $qRenameOriginalTables)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+				} else {
 					$update['status'][] = 'All original tables was renamed to *_old.';
 				}
 			}
@@ -1186,10 +1185,9 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					`". $db_settings['userdata_table'] ."_tmp` TO `". $db_settings['userdata_table'] ."`,
 					`". $db_settings['userdata_cache_table'] ."_tmp` TO `". $db_settings['userdata_cache_table'] ."`,
 					`". $db_settings['useronline_table'] ."_tmp` TO `". $db_settings['useronline_table'] ."`";
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, $qRenameTempTables)) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
+				if (!@mysqli_query($connid, $qRenameTempTables)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+				} else {
 					$update['status'][] = 'All temporary tables was renamed to their corresponding original names.';
 				}
 			}
@@ -1215,10 +1213,9 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					`". $db_settings['userdata_table'] ."_old`,
 					`". $db_settings['userdata_cache_table'] ."_old`,
 					`". $db_settings['useronline_table'] ."_old`";
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, $qDropOutdatedTables)) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
+				if (!mysqli_query($connid, $qDropOutdatedTables)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+				} else {
 					$update['status'][] = 'All outdated tables was removed from the database.';
 				}
 			}

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -344,6 +344,39 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 			}
 			
+			// changes in the temporary information table
+			$statusTestTempInfoTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['temp_infos_table'] ."_tmp` 
+					LIKE `". $db_settings['temp_infos_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestTempInfoTable = false;
+				} else {
+					$update['status'] = 'Temporary information table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['temp_infos_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['temp_infos_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestTempInfoTable = false;
+				} else {
+					$update['status'] = 'Data of temporary information table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['temp_infos_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestTempInfoTable = false;
+				} else {
+					$update['status'] = 'Structure of tags table altered.';
+				}
+			}
+			
 			
 			/**
 			 * From here on everything can be done as a transaction in one step

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -385,7 +385,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
-					$update['status'] = 'Banlists table created.';
+					$update['status'][] = 'Banlists table created.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -396,7 +396,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
-					$update['status'] = 'IP data of banlists table copied.';
+					$update['status'][] = 'IP data of banlists table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -407,7 +407,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
-					$update['status'] = 'User agents data of banlists table copied.';
+					$update['status'][] = 'User agents data of banlists table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -418,7 +418,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
-					$update['status'] = 'Bad words data of banlists table copied.';
+					$update['status'][] = 'Bad words data of banlists table copied.';
 				}
 			}
 			
@@ -431,7 +431,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
-					$update['status'] = 'Bookmarks table copied.';
+					$update['status'][] = 'Bookmarks table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -441,7 +441,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
-					$update['status'] = 'Data of bookmarks table copied.';
+					$update['status'][] = 'Data of bookmarks table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -451,7 +451,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
-					$update['status'] = 'Structure of bookmarks table altered.';
+					$update['status'][] = 'Structure of bookmarks table altered.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -463,7 +463,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
-					$update['status'] = 'Structure of columns in bookmarks table altered.';
+					$update['status'][] = 'Structure of columns in bookmarks table altered.';
 				}
 			}
 			
@@ -476,7 +476,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
-					$update['status'] = 'Bookmark tags table copied.';
+					$update['status'][] = 'Bookmark tags table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -486,7 +486,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
-					$update['status'] = 'Data of bookmark tags table copied.';
+					$update['status'][] = 'Data of bookmark tags table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -496,7 +496,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
-					$update['status'] = 'Structure of bookmark tags table altered.';
+					$update['status'][] = 'Structure of bookmark tags table altered.';
 				}
 			}
 			
@@ -509,7 +509,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
-					$update['status'] = 'Categories table copied.';
+					$update['status'][] = 'Categories table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -519,7 +519,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
-					$update['status'] = 'Data of categories table copied.';
+					$update['status'][] = 'Data of categories table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -529,7 +529,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
-					$update['status'] = 'Structure of categories table altered.';
+					$update['status'][] = 'Structure of categories table altered.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -539,7 +539,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
-					$update['status'] = 'Structure of columns in categories table altered.';
+					$update['status'][] = 'Structure of columns in categories table altered.';
 				}
 			}
 			
@@ -552,7 +552,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
-					$update['status'] = 'Entries cache table copied.';
+					$update['status'][] = 'Entries cache table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -562,7 +562,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
-					$update['status'] = 'Data of entries cache table copied.';
+					$update['status'][] = 'Data of entries cache table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -572,7 +572,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
-					$update['status'] = 'Structure of entries cache table altered.';
+					$update['status'][] = 'Structure of entries cache table altered.';
 				}
 			}
 			
@@ -585,7 +585,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
-					$update['status'] = 'Entry tags table copied.';
+					$update['status'][] = 'Entry tags table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -595,7 +595,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
-					$update['status'] = 'Data of entry tags table copied.';
+					$update['status'][] = 'Data of entry tags table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -605,7 +605,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
-					$update['status'] = 'Structure of entry tags table altered.';
+					$update['status'][] = 'Structure of entry tags table altered.';
 				}
 			}
 			
@@ -618,7 +618,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
-					$update['status'] = 'Login control table copied.';
+					$update['status'][] = 'Login control table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -628,7 +628,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
-					$update['status'] = 'Data of login control table copied.';
+					$update['status'][] = 'Data of login control table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -638,7 +638,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
-					$update['status'] = 'Structure of login control table altered.';
+					$update['status'][] = 'Structure of login control table altered.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -648,7 +648,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
-					$update['status'] = 'Structure of columns in login control table altered.';
+					$update['status'][] = 'Structure of columns in login control table altered.';
 				}
 			}
 			
@@ -661,7 +661,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
-					$update['status'] = 'Pages table copied.';
+					$update['status'][] = 'Pages table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -671,7 +671,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
-					$update['status'] = 'Data of pages table copied.';
+					$update['status'][] = 'Data of pages table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -681,7 +681,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
-					$update['status'] = 'Structure of pages table altered.';
+					$update['status'][] = 'Structure of pages table altered.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -691,7 +691,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
-					$update['status'] = 'Structure of columns in pages table altered.';
+					$update['status'][] = 'Structure of columns in pages table altered.';
 				}
 			}
 			
@@ -704,7 +704,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
-					$update['status'] = 'Read status table copied.';
+					$update['status'][] = 'Read status table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -714,7 +714,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
-					$update['status'] = 'Data of read status table copied.';
+					$update['status'][] = 'Data of read status table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -724,7 +724,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
-					$update['status'] = 'Structure of read status table altered.';
+					$update['status'][] = 'Structure of read status table altered.';
 				}
 			}
 			
@@ -737,7 +737,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
-					$update['status'] = 'Settings table copied.';
+					$update['status'][] = 'Settings table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -747,7 +747,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
-					$update['status'] = 'Data of settings table copied.';
+					$update['status'][] = 'Data of settings table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -757,7 +757,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
-					$update['status'] = 'Structure of settings table altered.';
+					$update['status'][] = 'Structure of settings table altered.';
 				}
 			}
 			
@@ -770,7 +770,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
-					$update['status'] = 'Smilies table copied.';
+					$update['status'][] = 'Smilies table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -780,7 +780,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
-					$update['status'] = 'Data of smilies table copied.';
+					$update['status'][] = 'Data of smilies table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -790,7 +790,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
-					$update['status'] = 'Structure of smilies table altered.';
+					$update['status'][] = 'Structure of smilies table altered.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -800,7 +800,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
-					$update['status'] = 'Structure of columns in smilies table altered.';
+					$update['status'][] = 'Structure of columns in smilies table altered.';
 				}
 			}
 			
@@ -813,7 +813,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
-					$update['status'] = 'Subscriptions table copied.';
+					$update['status'][] = 'Subscriptions table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -823,7 +823,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
-					$update['status'] = 'Data of subscriptions table copied.';
+					$update['status'][] = 'Data of subscriptions table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -833,7 +833,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
-					$update['status'] = 'Structure of subscriptions table altered.';
+					$update['status'][] = 'Structure of subscriptions table altered.';
 				}
 			}
 			
@@ -846,7 +846,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
-					$update['status'] = 'Tags table copied.';
+					$update['status'][] = 'Tags table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -856,7 +856,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
-					$update['status'] = 'Data of tags table copied.';
+					$update['status'][] = 'Data of tags table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -866,7 +866,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
-					$update['status'] = 'Structure of tags table altered.';
+					$update['status'][] = 'Structure of tags table altered.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -877,7 +877,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
-					$update['status'] = 'Structure of columns in tags table altered.';
+					$update['status'][] = 'Structure of columns in tags table altered.';
 				}
 			}
 			
@@ -890,7 +890,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
-					$update['status'] = 'Temporary information table copied.';
+					$update['status'][] = 'Temporary information table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -900,7 +900,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
-					$update['status'] = 'Data of temporary information table copied.';
+					$update['status'][] = 'Data of temporary information table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -910,7 +910,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
-					$update['status'] = 'Structure of temporary information table altered.';
+					$update['status'][] = 'Structure of temporary information table altered.';
 				}
 			}
 			
@@ -923,7 +923,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
-					$update['status'] = 'Userdata cache table copied.';
+					$update['status'][] = 'Userdata cache table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -933,7 +933,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
-					$update['status'] = 'Data of userdata cache table copied.';
+					$update['status'][] = 'Data of userdata cache table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -943,7 +943,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
-					$update['status'] = 'Structure of userdata cache table altered.';
+					$update['status'][] = 'Structure of userdata cache table altered.';
 				}
 			}
 			
@@ -956,7 +956,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
-					$update['status'] = 'User online table copied.';
+					$update['status'][] = 'User online table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -966,7 +966,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
-					$update['status'] = 'Data of user online table copied.';
+					$update['status'][] = 'Data of user online table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -976,7 +976,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
-					$update['status'] = 'Structure of user online table altered.';
+					$update['status'][] = 'Structure of user online table altered.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -987,7 +987,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
-					$update['status'] = 'Structure of columns in user online table altered.';
+					$update['status'][] = 'Structure of columns in user online table altered.';
 				}
 			}
 			

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,6 +301,39 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
+			// changes in the read entries table
+			$statusTestReadStatusTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['read_status_table'] ."_tmp` 
+					LIKE `". $db_settings['read_status_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestReadStatusTable = false;
+				} else {
+					$update['status'] = 'Read status table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['read_status_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['read_status_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestReadStatusTable = false;
+				} else {
+					$update['status'] = 'Data of read status table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['read_status_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestReadStatusTable = false;
+				} else {
+					$update['status'] = 'Structure of read status table altered.';
+				}
+			}
+			
 			// changes in the smilies table
 			$statusTestSmiliesTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1330,6 +1330,62 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				if (empty($update['errors'])) {
 					$update['status'][] = 'All temporary tables was renamed to their original names.';
 				}
+				
+				// delete all outdated *_old tables
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['banlists_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['bookmarks_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['bookmark_tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['category_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['entries_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['entry_cache_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['entry_tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['login_control_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['pages_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['read_status_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['settings_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['smilies_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['subscriptions_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['temp_infos_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['userdata_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['userdata_cache_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
+				if (empty($update['errors'])) {
+					if (!mysqli_query($connid, "DROP `". $db_settings['useronline_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+				}
 			}
 			
 			// write the new version number to the database

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1108,11 +1108,11 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					// change datasets in the entries table
 					mysqli_query($connid, "UPDATE `" . $db_settings['forum_table'] . "_tmp` SET
 					`last_reply` = NULL
-					WHERE `last_reply` <= STR_TO_DATE('1900-01-01','%Y-%d-%m');");
+					WHERE `last_reply` <= STR_TO_DATE('1970-01-01','%Y-%d-%m');");
 					
 					mysqli_query($connid, "UPDATE `" . $db_settings['forum_table'] . "_tmp` SET
 					`edited` = NULL
-					WHERE `edited` <= STR_TO_DATE('1900-01-01','%Y-%d-%m');");
+					WHERE `edited` <= STR_TO_DATE('1970-01-01','%Y-%d-%m');");
 					
 					mysqli_commit($connid);
 				} catch (mysqli_sql_exception $exception) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -592,7 +592,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 			}
 			if (empty($update['errors'])) {
-				$qSearch4email_notification = "SHOW COLUMNS FROM `". $db_settings['forum_table'] ."`
+				$qSearch4email_notification = "SHOW COLUMNS FROM `". $db_settings['forum_table'] ."_tmp`
 					LIKE 'email_notification';";
 				$qAlterTable = "ALTER TABLE `". $db_settings['forum_table'] ."_tmp`
 					DROP `email_notification`";

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,6 +301,70 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
+			// create the new introduced tables
+			// as first make column mlf2_userdata.user_id unsigned
+			// to prevent error when creating table mlf2_uploads
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `" . $db_settings['userdata_table'] . "`
+					CHANGE `user_id` `user_id` int UNSIGNED NOT NULL AUTO_INCREMENT";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+				}
+			}
+			
+			// new tables
+			if (empty($update['errors'])) {
+				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['akismet_rating_table'] . "` (
+					`eid` int(11) NOT NULL,
+					`spam` tinyint(1) NOT NULL DEFAULT '0',
+					`spam_check_status` tinyint(1) NOT NULL DEFAULT '0',
+					PRIMARY KEY (`eid`), KEY `akismet_spam` (`spam`), KEY spam_check_status (spam_check_status)
+				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
+				if (!mysqli_query($connid, $qCreateTable)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['b8_rating_table'] . "` (
+					`eid` int(11) NOT NULL,
+					`spam` tinyint(1) NOT NULL DEFAULT '0',
+					`training_type` tinyint(1) NOT NULL DEFAULT '0',
+					PRIMARY KEY (`eid`),
+					KEY `b8_spam` (`spam`),
+					KEY `B8_training_type` (`training_type`)
+				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
+				if (!mysqli_query($connid, $qCreateTable)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['b8_wordlist_table'] . "` (
+					`token` varchar(255) character set utf8mb4 collate utf8mb4_bin NOT NULL DEFAULT '',
+					`count_ham` int unsigned default NULL,
+					`count_spam` int unsigned default NULL,
+					PRIMARY KEY (`token`)
+				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
+				if (!mysqli_query($connid, $qCreateTable)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['uploads_table'] . "` (
+					`id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+					`uploader` int(10) UNSIGNED NULL,
+					`pathname` varchar(128) NOT NULL,
+					`tstamp` datetime NULL,
+					PRIMARY KEY (id),
+					UNIQUE KEY `pathname` (`pathname`),
+					CONSTRAINT `smbl_". $table_prefix ."uploader` FOREIGN KEY `fk_uploader` (`uploader`)
+						REFERENCES " . $db_settings['userdata_table'] . "(`user_id`) ON UPDATE CASCADE ON DELETE SET NULL
+				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
+				if (!mysqli_query($connid, $qCreateTable)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+				}
+			}
+			
+			
 			// changes in the banlist table
 			$statusTestBanlistsTable = true;
 			if (empty($update['errors'])) {
@@ -928,46 +992,6 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				mysqli_autocommit($connid, false);
 				mysqli_begin_transaction($connid);
 				try {
-					// create the new introduced tables
-					// as first make column mlf2_userdata.user_id unsigned
-					// to prevent error when creating table mlf2_uploads
-					mysqli_query($connid, "ALTER TABLE `" . $db_settings['userdata_table'] . "`
-					CHANGE `user_id` `user_id` int UNSIGNED NOT NULL AUTO_INCREMENT");
-					
-					// new tables
-					mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `" . $db_settings['akismet_rating_table'] . "` (
-						`eid` int(11) NOT NULL,
-						`spam` tinyint(1) NOT NULL DEFAULT '0',
-						`spam_check_status` tinyint(1) NOT NULL DEFAULT '0',
-						PRIMARY KEY (`eid`), KEY `akismet_spam` (`spam`), KEY spam_check_status (spam_check_status)
-					) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
-					
-					mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `" . $db_settings['b8_rating_table'] . "` (
-						`eid` int(11) NOT NULL,
-						`spam` tinyint(1) NOT NULL DEFAULT '0',
-						`training_type` tinyint(1) NOT NULL DEFAULT '0',
-						PRIMARY KEY (`eid`),
-						KEY `b8_spam` (`spam`),
-						KEY `B8_training_type` (`training_type`)
-					) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
-					
-					mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `" . $db_settings['b8_wordlist_table'] . "` (
-						`token` varchar(255) character set utf8mb4 collate utf8mb4_bin NOT NULL DEFAULT '',
-						`count_ham` int unsigned default NULL,
-						`count_spam` int unsigned default NULL,
-						PRIMARY KEY (`token`)
-					) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;");
-					
-					mysqli_query($connid, "CREATE TABLE IF NOT EXISTS `" . $db_settings['uploads_table'] . "` (
-						`id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
-						`uploader` int(10) UNSIGNED NULL,
-						`pathname` varchar(128) NOT NULL,
-						`tstamp` datetime NULL,
-						PRIMARY KEY (id),
-						UNIQUE KEY `pathname` (`pathname`),
-						CONSTRAINT `smbl_". $table_prefix ."uploader` FOREIGN KEY `fk_uploader` (`uploader`) REFERENCES " . $db_settings['userdata_table'] . "(`user_id`) ON UPDATE CASCADE ON DELETE SET NULL
-					) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;");
-					
 					// changes in the setting table
 					mysqli_query($connid, "ALTER TABLE `" . $db_settings['settings_table'] . "`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,78 +301,6 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
-			// create the new introduced tables
-			// as first make column mlf2_userdata.user_id unsigned
-			// to prevent error when creating table mlf2_uploads
-			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `" . $db_settings['userdata_table'] . "`
-					CHANGE `user_id` `user_id` int UNSIGNED NOT NULL AUTO_INCREMENT";
-				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-				}
-			}
-			
-			// new tables
-			if (empty($update['errors'])) {
-				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['akismet_rating_table'] . "` (
-					`eid` int(11) NOT NULL,
-					`spam` tinyint(1) NOT NULL DEFAULT '0',
-					`spam_check_status` tinyint(1) NOT NULL DEFAULT '0',
-					PRIMARY KEY (`eid`), KEY `akismet_spam` (`spam`), KEY spam_check_status (spam_check_status)
-				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-				if (!mysqli_query($connid, $qCreateTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-				} else {
-					$update['status'][] = 'Posting rating table for the Akismet filter created.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['b8_rating_table'] . "` (
-					`eid` int(11) NOT NULL,
-					`spam` tinyint(1) NOT NULL DEFAULT '0',
-					`training_type` tinyint(1) NOT NULL DEFAULT '0',
-					PRIMARY KEY (`eid`),
-					KEY `b8_spam` (`spam`),
-					KEY `B8_training_type` (`training_type`)
-				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
-				if (!mysqli_query($connid, $qCreateTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-				} else {
-					$update['status'][] = 'Posting rating table for the Bayesian filter created.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['b8_wordlist_table'] . "` (
-					`token` varchar(255) character set utf8mb4 collate utf8mb4_bin NOT NULL DEFAULT '',
-					`count_ham` int unsigned default NULL,
-					`count_spam` int unsigned default NULL,
-					PRIMARY KEY (`token`)
-				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
-				if (!mysqli_query($connid, $qCreateTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-				} else {
-					$update['status'][] = 'Wordlist table for the Bayesian filter created.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['uploads_table'] . "` (
-					`id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
-					`uploader` int(10) UNSIGNED NULL,
-					`pathname` varchar(128) NOT NULL,
-					`tstamp` datetime NULL,
-					PRIMARY KEY (id),
-					UNIQUE KEY `pathname` (`pathname`),
-					CONSTRAINT `smbl_". $table_prefix ."uploader` FOREIGN KEY `fk_uploader` (`uploader`)
-						REFERENCES " . $db_settings['userdata_table'] . "(`user_id`) ON UPDATE CASCADE ON DELETE SET NULL
-				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
-				if (!mysqli_query($connid, $qCreateTable)) {
-					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-				} else {
-					$update['status'][] = 'Uploads table created.';
-				}
-			}
-			
-			
 			// changes in the banlist table
 			$statusTestBanlistsTable = true;
 			if (empty($update['errors'])) {
@@ -1021,6 +949,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			if (empty($update['errors'])) {
 				$qAlterTable = "ALTER TABLE `". $db_settings['userdata_table'] ."_tmp`
+					CHANGE `user_id` `user_id` int UNSIGNED NOT NULL AUTO_INCREMENT,
 					CHANGE `user_name` `user_name` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
 					CHANGE `user_email` `user_email` VARCHAR(255) NOT NULL,
 					CHANGE `birthday` `birthday` DATE NULL DEFAULT NULL,
@@ -1080,16 +1009,38 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['useronline_table'] ."_tmp` 
 					LIKE `". $db_settings['useronline_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
+			// create the new introduced tables
+			if (empty($update['errors'])) {
+				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['akismet_rating_table'] . "` (
+					`eid` int(11) NOT NULL,
+					`spam` tinyint(1) NOT NULL DEFAULT '0',
+					`spam_check_status` tinyint(1) NOT NULL DEFAULT '0',
+					PRIMARY KEY (`eid`), KEY `akismet_spam` (`spam`), KEY spam_check_status (spam_check_status)
+				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
+				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
 					$update['status'][] = 'User online table copied.';
+				} else {
+					$update['status'][] = 'Posting rating table for the Akismet filter created.';
 				}
 			}
 			if (empty($update['errors'])) {
 				$qCopyData = "INSERT `". $db_settings['useronline_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['useronline_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
+			}
+			if (empty($update['errors'])) {
+				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['b8_rating_table'] . "` (
+					`eid` int(11) NOT NULL,
+					`spam` tinyint(1) NOT NULL DEFAULT '0',
+					`training_type` tinyint(1) NOT NULL DEFAULT '0',
+					PRIMARY KEY (`eid`),
+					KEY `b8_spam` (`spam`),
+					KEY `B8_training_type` (`training_type`)
+				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
+				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
@@ -1100,10 +1051,24 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['useronline_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
+				} else {
+					$update['status'][] = 'Posting rating table for the Bayesian filter created.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['b8_wordlist_table'] . "` (
+					`token` varchar(255) character set utf8mb4 collate utf8mb4_bin NOT NULL DEFAULT '',
+					`count_ham` int unsigned default NULL,
+					`count_spam` int unsigned default NULL,
+					PRIMARY KEY (`token`)
+				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
+				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
 					$update['status'][] = 'Structure of user online table altered.';
+				} else {
+					$update['status'][] = 'Wordlist table for the Bayesian filter created.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -1111,10 +1076,25 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default '',
 					CHANGE `user_id` `user_id` int UNSIGNED DEFAULT '0'";
 				if (!mysqli_query($connid, $qAlterTable)) {
+			if (empty($update['errors'])) {
+				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['uploads_table'] . "` (
+					`id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+					`uploader` int(10) UNSIGNED NULL,
+					`pathname` varchar(128) NOT NULL,
+					`tstamp` datetime NULL,
+					PRIMARY KEY (id),
+					UNIQUE KEY `pathname` (`pathname`),
+					CONSTRAINT `smbl_". $table_prefix ."uploader` FOREIGN KEY `fk_uploader` (`uploader`)
+						REFERENCES " . $db_settings['userdata_table'] . "_tmp(`user_id`) ON UPDATE CASCADE ON DELETE SET NULL
+				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
+				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
 					$update['status'][] = 'Structure of columns in user online table altered.';
+				}
+				} else {
+					$update['status'][] = 'Uploads table created.';
 				}
 			}
 			

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,6 +301,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
+			// change the existing tables
+			// do it before creating the new tables
 			// changes in the banlist table
 			$statusTestBanlistsTable = true;
 			if (empty($update['errors'])) {
@@ -1009,6 +1011,45 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['useronline_table'] ."_tmp` 
 					LIKE `". $db_settings['useronline_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserOnlineTable = false;
+				} else {
+					$update['status'][] = 'User online table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['useronline_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['useronline_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserOnlineTable = false;
+				} else {
+					$update['status'][] = 'Data of user online table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['useronline_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserOnlineTable = false;
+				} else {
+					$update['status'][] = 'Structure of user online table altered.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['useronline_table'] ."_tmp`
+					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default '',
+					CHANGE `user_id` `user_id` int UNSIGNED DEFAULT '0'";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserOnlineTable = false;
+				} else {
+					$update['status'][] = 'Structure of columns in user online table altered.';
+				}
+			}
+			
+			
 			// create the new introduced tables
 			if (empty($update['errors'])) {
 				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['akismet_rating_table'] . "` (
@@ -1019,17 +1060,9 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
 				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestUserOnlineTable = false;
-				} else {
-					$update['status'][] = 'User online table copied.';
 				} else {
 					$update['status'][] = 'Posting rating table for the Akismet filter created.';
 				}
-			}
-			if (empty($update['errors'])) {
-				$qCopyData = "INSERT `". $db_settings['useronline_table'] ."_tmp`
-					SELECT * FROM `". $db_settings['useronline_table'] ."`;";
-				if (!mysqli_query($connid, $qCopyData)) {
 			}
 			if (empty($update['errors'])) {
 				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['b8_rating_table'] . "` (
@@ -1042,15 +1075,6 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;";
 				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestUserOnlineTable = false;
-				} else {
-					$update['status'][] = 'Data of user online table copied.';
-				}
-			}
-			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['useronline_table'] ."_tmp`
-					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-				if (!mysqli_query($connid, $qAlterTable)) {
 				} else {
 					$update['status'][] = 'Posting rating table for the Bayesian filter created.';
 				}
@@ -1064,18 +1088,10 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
 				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestUserOnlineTable = false;
-				} else {
-					$update['status'][] = 'Structure of user online table altered.';
 				} else {
 					$update['status'][] = 'Wordlist table for the Bayesian filter created.';
 				}
 			}
-			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['useronline_table'] ."_tmp`
-					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default '',
-					CHANGE `user_id` `user_id` int UNSIGNED DEFAULT '0'";
-				if (!mysqli_query($connid, $qAlterTable)) {
 			if (empty($update['errors'])) {
 				$qCreateTable = "CREATE TABLE IF NOT EXISTS `" . $db_settings['uploads_table'] . "` (
 					`id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -1089,10 +1105,6 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_bin;";
 				if (!mysqli_query($connid, $qCreateTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
-					$statusTestUserOnlineTable = false;
-				} else {
-					$update['status'][] = 'Structure of columns in user online table altered.';
-				}
 				} else {
 					$update['status'][] = 'Uploads table created.';
 				}

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -425,8 +425,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the bookmarks table
 			$statusTestBookmarksTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmarks_table'] ."_tmp` 
-					LIKE `". $db_settings['bookmarks_table'] ."`;";
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmark_table'] ."_tmp` 
+					LIKE `". $db_settings['bookmark_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
@@ -435,8 +435,8 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 			}
 			if (empty($update['errors'])) {
-				$qCopyData = "INSERT `". $db_settings['bookmarks_table'] ."_tmp`
-					SELECT * FROM `". $db_settings['bookmarks_table'] ."`;";
+				$qCopyData = "INSERT `". $db_settings['bookmark_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['bookmark_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
@@ -445,7 +445,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 			}
 			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['bookmarks_table'] ."_tmp`
+				$qAlterTable = "ALTER TABLE `". $db_settings['bookmark_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -455,7 +455,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 			}
 			if (empty($update['errors'])) {
-				$qAlterTable = "ALTER TABLE `". $db_settings['bookmarks_table'] ."_tmp`
+				$qAlterTable = "ALTER TABLE `". $db_settings['bookmark_table'] ."_tmp`
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
 					CHANGE `user_id` `user_id` int UNSIGNED NOT NULL,
 					CHANGE `posting_id` `posting_id` int UNSIGNED NOT NULL";
@@ -1218,7 +1218,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					if (!mysqli_query($connid, "RENAME `". $db_settings['banlists_table'] ."` TO `". $db_settings['banlists_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 				}
 				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmarks_table'] ."` TO `". $db_settings['bookmarks_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmark_table'] ."` TO `". $db_settings['bookmark_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 				}
 				if (empty($update['errors'])) {
 					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmark_tags_table'] ."` TO `". $db_settings['bookmark_tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
@@ -1277,7 +1277,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					if (!mysqli_query($connid, "RENAME `". $db_settings['banlists_table'] ."_tmp` TO `". $db_settings['banlists_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 				}
 				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmarks_table'] ."_tmp` TO `". $db_settings['bookmarks_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmark_table'] ."_tmp` TO `". $db_settings['bookmark_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 				}
 				if (empty($update['errors'])) {
 					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmark_tags_table'] ."_tmp` TO `". $db_settings['bookmark_tags_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
@@ -1336,7 +1336,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					if (!mysqli_query($connid, "DROP `". $db_settings['banlists_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 				}
 				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "DROP `". $db_settings['bookmarks_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+					if (!mysqli_query($connid, "DROP `". $db_settings['bookmark_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 				}
 				if (empty($update['errors'])) {
 					if (!mysqli_query($connid, "DROP `". $db_settings['bookmark_tags_table'] ."_old`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -374,7 +374,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					PRIMARY KEY (`name`)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
 					$update['status'] = 'Banlists table created.';
@@ -385,7 +385,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
 					FROM `". $db_settings['banlists_table'] ."` WHERE `name` = 'ips';";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
 					$update['status'] = 'IP data of banlists table copied.';
@@ -396,7 +396,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
 					FROM `". $db_settings['banlists_table'] ."` WHERE `name` = 'user_agents';";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
 					$update['status'] = 'User agents data of banlists table copied.';
@@ -407,7 +407,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					SELECT `name`, GROUP_CONCAT(`list` SEPARATOR '\n') AS `list`
 					FROM `". $db_settings['banlists_table'] ."` WHERE `name` = 'words';";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {
 					$update['status'] = 'Bad words data of banlists table copied.';
@@ -420,7 +420,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmarks_table'] ."_tmp` 
 					LIKE `". $db_settings['bookmarks_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
 					$update['status'] = 'Bookmarks table copied.';
@@ -430,7 +430,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['bookmarks_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['bookmarks_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
 					$update['status'] = 'Data of bookmarks table copied.';
@@ -440,7 +440,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['bookmarks_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
 					$update['status'] = 'Structure of bookmarks table altered.';
@@ -452,7 +452,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CHANGE `user_id` `user_id` int UNSIGNED NOT NULL,
 					CHANGE `posting_id` `posting_id` int UNSIGNED NOT NULL";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarksTable = false;
 				} else {
 					$update['status'] = 'Structure of columns in bookmarks table altered.';
@@ -465,7 +465,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmark_tags_table'] ."_tmp` 
 					LIKE `". $db_settings['bookmark_tags_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
 					$update['status'] = 'Bookmark tags table copied.';
@@ -475,7 +475,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['bookmark_tags_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['bookmark_tags_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
 					$update['status'] = 'Data of bookmark tags table copied.';
@@ -485,7 +485,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['bookmark_tags_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBookmarkTagsTable = false;
 				} else {
 					$update['status'] = 'Structure of bookmark tags table altered.';
@@ -498,7 +498,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['category_table'] ."_tmp` 
 					LIKE `". $db_settings['category_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
 					$update['status'] = 'Categories table copied.';
@@ -508,7 +508,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['category_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['category_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
 					$update['status'] = 'Data of categories table copied.';
@@ -518,7 +518,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['category_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
 					$update['status'] = 'Structure of categories table altered.';
@@ -528,7 +528,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['category_table'] ."_tmp`
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestCategoriesTable = false;
 				} else {
 					$update['status'] = 'Structure of columns in categories table altered.';
@@ -541,7 +541,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_cache_table'] ."_tmp` 
 					LIKE `". $db_settings['entry_cache_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
 					$update['status'] = 'Entries cache table copied.';
@@ -551,7 +551,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['entry_cache_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['entry_cache_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
 					$update['status'] = 'Data of entries cache table copied.';
@@ -561,7 +561,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['entry_cache_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntriesCacheTable = false;
 				} else {
 					$update['status'] = 'Structure of entries cache table altered.';
@@ -574,7 +574,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_tags_table'] ."_tmp` 
 					LIKE `". $db_settings['entry_tags_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
 					$update['status'] = 'Entry tags table copied.';
@@ -584,7 +584,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['entry_tags_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['entry_tags_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
 					$update['status'] = 'Data of entry tags table copied.';
@@ -594,7 +594,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['entry_tags_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestEntryTagsTable = false;
 				} else {
 					$update['status'] = 'Structure of entry tags table altered.';
@@ -607,7 +607,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['login_control_table'] ."_tmp` 
 					LIKE `". $db_settings['login_control_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
 					$update['status'] = 'Login control table copied.';
@@ -617,7 +617,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['login_control_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['login_control_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
 					$update['status'] = 'Data of login control table copied.';
@@ -627,7 +627,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['login_control_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
 					$update['status'] = 'Structure of login control table altered.';
@@ -637,7 +637,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['login_control_table'] ."_tmp`
 					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default ''";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestLoginControlTable = false;
 				} else {
 					$update['status'] = 'Structure of columns in login control table altered.';
@@ -650,7 +650,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['pages_table'] ."_tmp` 
 					LIKE `". $db_settings['pages_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
 					$update['status'] = 'Pages table copied.';
@@ -660,7 +660,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['pages_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['pages_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
 					$update['status'] = 'Data of pages table copied.';
@@ -670,7 +670,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['pages_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
 					$update['status'] = 'Structure of pages table altered.';
@@ -680,7 +680,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['pages_table'] ."_tmp`
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestPagesTable = false;
 				} else {
 					$update['status'] = 'Structure of columns in pages table altered.';
@@ -693,7 +693,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['read_status_table'] ."_tmp` 
 					LIKE `". $db_settings['read_status_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
 					$update['status'] = 'Read status table copied.';
@@ -703,7 +703,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['read_status_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['read_status_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
 					$update['status'] = 'Data of read status table copied.';
@@ -713,7 +713,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['read_status_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestReadStatusTable = false;
 				} else {
 					$update['status'] = 'Structure of read status table altered.';
@@ -726,7 +726,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['settings_table'] ."_tmp` 
 					LIKE `". $db_settings['settings_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
 					$update['status'] = 'Settings table copied.';
@@ -736,7 +736,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['settings_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['settings_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
 					$update['status'] = 'Data of settings table copied.';
@@ -746,7 +746,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['settings_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSettingsTable = false;
 				} else {
 					$update['status'] = 'Structure of settings table altered.';
@@ -759,7 +759,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['smilies_table'] ."_tmp` 
 					LIKE `". $db_settings['smilies_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
 					$update['status'] = 'Smilies table copied.';
@@ -769,7 +769,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['smilies_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['smilies_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
 					$update['status'] = 'Data of smilies table copied.';
@@ -779,7 +779,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['smilies_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
 					$update['status'] = 'Structure of smilies table altered.';
@@ -789,7 +789,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['smilies_table'] ."_tmp`
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSmiliesTable = false;
 				} else {
 					$update['status'] = 'Structure of columns in smilies table altered.';
@@ -802,7 +802,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['subscriptions_table'] ."_tmp` 
 					LIKE `". $db_settings['subscriptions_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
 					$update['status'] = 'Subscriptions table copied.';
@@ -812,7 +812,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['subscriptions_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['subscriptions_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
 					$update['status'] = 'Data of subscriptions table copied.';
@@ -822,7 +822,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['subscriptions_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestSubscriptionsTable = false;
 				} else {
 					$update['status'] = 'Structure of subscriptions table altered.';
@@ -835,7 +835,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['tags_table'] ."_tmp` 
 					LIKE `". $db_settings['tags_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
 					$update['status'] = 'Tags table copied.';
@@ -845,7 +845,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['tags_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['tags_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
 					$update['status'] = 'Data of tags table copied.';
@@ -855,7 +855,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['tags_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
 					$update['status'] = 'Structure of tags table altered.';
@@ -866,7 +866,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CHANGE `tag` `tag` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
 					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTagsTable = false;
 				} else {
 					$update['status'] = 'Structure of columns in tags table altered.';
@@ -879,7 +879,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['temp_infos_table'] ."_tmp` 
 					LIKE `". $db_settings['temp_infos_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
 					$update['status'] = 'Temporary information table copied.';
@@ -889,7 +889,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['temp_infos_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['temp_infos_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
 					$update['status'] = 'Data of temporary information table copied.';
@@ -899,7 +899,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['temp_infos_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestTempInfoTable = false;
 				} else {
 					$update['status'] = 'Structure of temporary information table altered.';
@@ -912,7 +912,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_cache_table'] ."_tmp` 
 					LIKE `". $db_settings['userdata_cache_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
 					$update['status'] = 'Userdata cache table copied.';
@@ -922,7 +922,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['userdata_cache_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['userdata_cache_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
 					$update['status'] = 'Data of userdata cache table copied.';
@@ -932,7 +932,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['userdata_cache_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserdataCacheTable = false;
 				} else {
 					$update['status'] = 'Structure of userdata cache table altered.';
@@ -945,7 +945,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['useronline_table'] ."_tmp` 
 					LIKE `". $db_settings['useronline_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
 					$update['status'] = 'User online table copied.';
@@ -955,7 +955,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qCopyData = "INSERT `". $db_settings['useronline_table'] ."_tmp`
 					SELECT * FROM `". $db_settings['useronline_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyData)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
 					$update['status'] = 'Data of user online table copied.';
@@ -965,7 +965,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				$qAlterTable = "ALTER TABLE `". $db_settings['useronline_table'] ."_tmp`
 					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
 					$update['status'] = 'Structure of user online table altered.';
@@ -976,7 +976,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default '',
 					CHANGE `user_id` `user_id` int UNSIGNED DEFAULT '0'";
 				if (!mysqli_query($connid, $qAlterTable)) {
-					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
 					$update['status'] = 'Structure of columns in user online table altered.';

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -377,6 +377,51 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 			}
 			
+			// changes in the user online table
+			$statusTestUserOnlineTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['useronline_table'] ."_tmp` 
+					LIKE `". $db_settings['useronline_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserOnlineTable = false;
+				} else {
+					$update['status'] = 'Temporary information table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['useronline_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['useronline_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserOnlineTable = false;
+				} else {
+					$update['status'] = 'Data of temporary information table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['useronline_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserOnlineTable = false;
+				} else {
+					$update['status'] = 'Structure of tags table altered.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['useronline_table'] ."_tmp`
+					CHANGE `ip` `ip` VARCHAR(128) NOT NULL default '',
+					CHANGE `user_id` `user_id` int UNSIGNED DEFAULT '0'";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserOnlineTable = false;
+				} else {
+					$update['status'] = 'Structure of columns in tags table altered.';
+				}
+			}
+			
+			
 			
 			/**
 			 * From here on everything can be done as a transaction in one step

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -579,7 +579,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 							$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 							$statusTestEntriesTable = false;
 						} else {
-							$update['status'][] = 'Removed obsolete column email_notofications from the forum entries table.';
+							$update['status'][] = 'Removed obsolete column email_notification from the forum entries table.';
 						}
 					}
 				}

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -842,6 +842,39 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 			}
 			
+			// changes in the user data cache table
+			$statusTestUserdataCacheTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_cache_table'] ."_tmp` 
+					LIKE `". $db_settings['userdata_cache_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserdataCacheTable = false;
+				} else {
+					$update['status'] = 'Userdata cache table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['userdata_cache_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['userdata_cache_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserdataCacheTable = false;
+				} else {
+					$update['status'] = 'Data of userdata cache table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['userdata_cache_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestUserdataCacheTable = false;
+				} else {
+					$update['status'] = 'Structure of userdata cache table altered.';
+				}
+			}
+			
 			// changes in the user online table
 			$statusTestUserOnlineTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1127,8 +1127,16 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				mysqli_autocommit($connid, false);
 				mysqli_begin_transaction($connid);
 				try {
+					/**
+					 * add, change or remove datasets
+					 *
+					 * Attention: all datasets will be added to, changed in, or removed from the temporary tables.
+					 * The only exception from this rule are the datasets that are stored in the new tables.
+					 */
+					
+					// add new datasets to the settings table
 					$uaa = ($settings['user_area_public'] == 0) ? 2 : 1;
-					mysqli_query($connid, "INSERT INTO `" . $db_settings['settings_table'] . "` (`name`, `value`)
+					mysqli_query($connid, "INSERT INTO `" . $db_settings['settings_table'] . "_tmp` (`name`, `value`)
 					VALUES
 						('uploads_per_page', '20'),
 						('bbcode_latex', '0'),
@@ -1144,11 +1152,13 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 						('link_open_target', ''),
 						('bbcode_media', '0');");
 					
-					mysqli_query($connid, "UPDATE `" . $db_settings['settings_table'] . "` SET
+					// change datasets in the settings table
+					mysqli_query($connid, "UPDATE `" . $db_settings['settings_table'] . "_tmp` SET
 						`name`='spam_check_registered'
 					WHERE `name`='akismet_check_registered';");
 					
-					mysqli_query($connid, "DELETE FROM `" . $db_settings['settings_table'] . "`
+					// delete outdated datasets from the settings table
+					mysqli_query($connid, "DELETE FROM `" . $db_settings['settings_table'] . "_tmp`
 					WHERE name IN(
 						'bbcode_flash',
 						'bbcode_tex',
@@ -1158,7 +1168,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 						'bad_behavior');");
 					
 					
-					// changes in the new introduced tables
+					// add new datasets to the new introduced tables
 					mysqli_query($connid, "INSERT INTO `" . $db_settings['b8_wordlist_table'] . "` (`token`, `count_ham`, `count_spam`)
 					VALUES
 						('b8*dbversion', '3', NULL),
@@ -1171,23 +1181,25 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					SELECT `id`, `spam`, 0 FROM `" . $db_settings['forum_table'] ."`;");
 					
 					
-					mysqli_query($connid, "UPDATE `" . $db_settings['userdata_table'] . "` SET
+					// change datasets in the user data table
+					mysqli_query($connid, "UPDATE `" . $db_settings['userdata_table'] . "_tmp` SET
 					`birthday` = NULL
 					WHERE `birthday` <= STR_TO_DATE('1900-01-01','%Y-%d-%m');");
 					
-					mysqli_query($connid, "UPDATE `" . $db_settings['userdata_table'] . "` SET
+					mysqli_query($connid, "UPDATE `" . $db_settings['userdata_table'] . "_tmp` SET
 					`last_logout` = NULL
 					WHERE `last_logout` <= STR_TO_DATE('1900-01-01','%Y-%d-%m');");
 					
-					mysqli_query($connid, "UPDATE `" . $db_settings['userdata_table'] . "` SET
+					mysqli_query($connid, "UPDATE `" . $db_settings['userdata_table'] . "_tmp` SET
 					`registered` = NULL
 					
 					
-					mysqli_query($connid, "UPDATE `" . $db_settings['forum_table'] . "` SET
+					// change datasets in the user entries table
+					mysqli_query($connid, "UPDATE `" . $db_settings['forum_table'] . "_tmp` SET
 					`last_reply` = NULL
 					WHERE `last_reply` <= STR_TO_DATE('1900-01-01','%Y-%d-%m');");
 					
-					mysqli_query($connid, "UPDATE `" . $db_settings['forum_table'] . "` SET
+					mysqli_query($connid, "UPDATE `" . $db_settings['forum_table'] . "_tmp` SET
 					`edited` = NULL
 					WHERE `edited` <= STR_TO_DATE('1900-01-01','%Y-%d-%m');");
 					

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1221,59 +1221,27 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 				
 				// rename the temporary tables to the original table names
+				$qRenameTempTables = "RENAME TABLE
+					`". $db_settings['banlists_table'] ."_tmp` TO `". $db_settings['banlists_table'] ."`,
+					`". $db_settings['bookmark_table'] ."_tmp` TO `". $db_settings['bookmark_table'] ."`,
+					`". $db_settings['bookmark_tags_table'] ."_tmp` TO `". $db_settings['bookmark_tags_table'] ."`,
+					`". $db_settings['category_table'] ."_tmp` TO `". $db_settings['category_table'] ."`,
+					`". $db_settings['forum_table'] ."_tmp` TO `". $db_settings['forum_table'] ."`,
+					`". $db_settings['entry_cache_table'] ."_tmp` TO `". $db_settings['entry_cache_table'] ."`,
+					`". $db_settings['entry_tags_table'] ."_tmp` TO `". $db_settings['entry_tags_table'] ."`,
+					`". $db_settings['login_control_table'] ."_tmp` TO `". $db_settings['login_control_table'] ."`,
+					`". $db_settings['pages_table'] ."_tmp` TO `". $db_settings['pages_table'] ."`,
+					`". $db_settings['read_status_table'] ."_tmp` TO `". $db_settings['read_status_table'] ."`,
+					`". $db_settings['settings_table'] ."_tmp` TO `". $db_settings['settings_table'] ."`,
+					`". $db_settings['smilies_table'] ."_tmp` TO `". $db_settings['smilies_table'] ."`,
+					`". $db_settings['subscriptions_table'] ."_tmp` TO `". $db_settings['subscriptions_table'] ."`,
+					`". $db_settings['tags_table'] ."_tmp` TO `". $db_settings['tags_table'] ."`,
+					`". $db_settings['temp_infos_table'] ."_tmp` TO `". $db_settings['temp_infos_table'] ."`,
+					`". $db_settings['userdata_table'] ."_tmp` TO `". $db_settings['userdata_table'] ."`,
+					`". $db_settings['userdata_cache_table'] ."_tmp` TO `". $db_settings['userdata_cache_table'] ."`,
+					`". $db_settings['useronline_table'] ."_tmp` TO `". $db_settings['useronline_table'] ."`";
 				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['banlists_table'] ."_tmp` TO `". $db_settings['banlists_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmark_table'] ."_tmp` TO `". $db_settings['bookmark_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['bookmark_tags_table'] ."_tmp` TO `". $db_settings['bookmark_tags_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['category_table'] ."_tmp` TO `". $db_settings['category_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['entries_table'] ."_tmp` TO `". $db_settings['entries_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['entry_cache_table'] ."_tmp` TO `". $db_settings['entry_cache_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['entry_tags_table'] ."_tmp` TO `". $db_settings['entry_tags_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['login_control_table'] ."_tmp` TO `". $db_settings['login_control_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['pages_table'] ."_tmp` TO `". $db_settings['pages_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['read_status_table'] ."_tmp` TO `". $db_settings['read_status_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['settings_table'] ."_tmp` TO `". $db_settings['settings_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['smilies_table'] ."_tmp` TO `". $db_settings['smilies_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['subscriptions_table'] ."_tmp` TO `". $db_settings['subscriptions_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['tags_table'] ."_tmp` TO `". $db_settings['tags_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['temp_infos_table'] ."_tmp` TO `". $db_settings['temp_infos_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['userdata_table'] ."_tmp` TO `". $db_settings['userdata_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['userdata_cache_table'] ."_tmp` TO `". $db_settings['userdata_cache_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
-				}
-				if (empty($update['errors'])) {
-					if (!mysqli_query($connid, "RENAME `". $db_settings['useronline_table'] ."_tmp` TO `". $db_settings['useronline_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
+					if (!mysqli_query($connid, $qRenameTempTables)) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 				}
 				if (empty($update['errors'])) {
 					$update['status'][] = 'All temporary tables was renamed to their corresponding original names.';

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -19,6 +19,7 @@ if($_SESSION[$settings['session_prefix'].'user_type']!=2) exit;
 // defaults to these values with PHP 8.1 and newer
 // but is needed for older PHP versions because it
 // defaults to MYSQLI_REPORT_OFF there 
+// Attention: for specific sections it will be reset to MYSQLI_REPORT_OFF and on again.
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
 // update data:
@@ -294,6 +295,12 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			fwrite($db_settings_fp, $db_settings_file);
 			flock($db_settings_fp, 3);
 			fclose($db_settings_fp);
+			
+			// Set MySQL error reporting to MYSQLI_REPORT_OFF because otherwise
+			// the mechanism with $update['errors'][] wouldn't work!
+			// The reporting has to be reset to MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT
+			// again before the section with the transaction begins!
+			mysqli_report(MYSQLI_REPORT_OFF);
 			// drop possibly existing new tables from previous tests with a pre release
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['akismet_rating_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['b8_rating_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
@@ -1030,6 +1037,9 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			
 			
+			// Set the error reporting back to MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT
+			// to make the reporting working in the try-catch-block.
+			mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 			/**
 			 * Everything regarding new, changed or removed datasets can be done as a transaction in one step
 			 */
@@ -1123,6 +1133,9 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			}
 			
 			
+			// Set MySQL error reporting to MYSQLI_REPORT_OFF because otherwise
+			// the mechanism with $update['errors'][] wouldn't work!
+			mysqli_report(MYSQLI_REPORT_OFF);
 			if (empty($update['errors'])) {
 				// rename the original tables
 				$qRenameOriginalTables = "RENAME TABLE

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -386,7 +386,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
-					$update['status'] = 'Temporary information table copied.';
+					$update['status'] = 'User online table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -396,7 +396,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
-					$update['status'] = 'Data of temporary information table copied.';
+					$update['status'] = 'Data of user online table copied.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -406,7 +406,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
-					$update['status'] = 'Structure of tags table altered.';
+					$update['status'] = 'Structure of user online table altered.';
 				}
 			}
 			if (empty($update['errors'])) {
@@ -417,7 +417,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestUserOnlineTable = false;
 				} else {
-					$update['status'] = 'Structure of columns in tags table altered.';
+					$update['status'] = 'Structure of columns in user online table altered.';
 				}
 			}
 			

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -1328,7 +1328,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 					if (!mysqli_query($connid, "RENAME `". $db_settings['useronline_table'] ."_tmp` TO `". $db_settings['useronline_table'] ."`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 				}
 				if (empty($update['errors'])) {
-					$update['status'][] = 'All temporary tables was renamed to their original names.';
+					$update['status'][] = 'All temporary tables was renamed to their corresponding original names.';
 				}
 				
 				// delete all outdated *_old tables

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -376,12 +376,12 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the banlist table
 			$statusTestBanlistsTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."_tmp` (
+				$qCreateTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['banlists_table'] ."_tmp` (
 					`name` varchar(255) COLLATE utf8mb4_bin NOT NULL,
 					`list` text COLLATE=utf8mb4_general_ci NULL DEFAULT NULL,
 					PRIMARY KEY (`name`)
 				) ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
-				if (!mysqli_query($connid, $qCopyTable) {
+				if (!mysqli_query($connid, $qCreateTable) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
 					$statusTestBanlistsTable = false;
 				} else {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -355,7 +355,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the bookmarks table
 			$statusTestBookmarksTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmark_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmark_table'] ."_tmp`
 					LIKE `". $db_settings['bookmark_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -400,7 +400,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the bookmark tags table
 			$statusTestBookmarkTagsTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmark_tags_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmark_tags_table'] ."_tmp`
 					LIKE `". $db_settings['bookmark_tags_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -433,7 +433,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the categories table
 			$statusTestCategoriesTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['category_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['category_table'] ."_tmp`
 					LIKE `". $db_settings['category_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -476,7 +476,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the entry cache table
 			$statusTestEntriesCacheTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_cache_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_cache_table'] ."_tmp`
 					LIKE `". $db_settings['entry_cache_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -509,7 +509,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the entry tags table
 			$statusTestEntryTagsTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_tags_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_tags_table'] ."_tmp`
 					LIKE `". $db_settings['entry_tags_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -542,7 +542,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the forum/entries table
 			$statusTestEntriesTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['forum_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['forum_table'] ."_tmp`
 					LIKE `". $db_settings['forum_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -615,7 +615,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the login control table
 			$statusTestLoginControlTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['login_control_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['login_control_table'] ."_tmp`
 					LIKE `". $db_settings['login_control_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -658,7 +658,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the pages table
 			$statusTestPagesTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['pages_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['pages_table'] ."_tmp`
 					LIKE `". $db_settings['pages_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -701,7 +701,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the read entries table
 			$statusTestReadStatusTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['read_status_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['read_status_table'] ."_tmp`
 					LIKE `". $db_settings['read_status_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -734,7 +734,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the setting table
 			$statusTestSettingsTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['settings_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['settings_table'] ."_tmp`
 					LIKE `". $db_settings['settings_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -767,7 +767,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the smilies table
 			$statusTestSmiliesTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['smilies_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['smilies_table'] ."_tmp`
 					LIKE `". $db_settings['smilies_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -810,7 +810,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the subscriptions table
 			$statusTestSubscriptionsTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['subscriptions_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['subscriptions_table'] ."_tmp`
 					LIKE `". $db_settings['subscriptions_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -843,7 +843,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes of the tags table
 			$statusTestTagsTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['tags_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['tags_table'] ."_tmp`
 					LIKE `". $db_settings['tags_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -887,7 +887,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the temporary information table
 			$statusTestTempInfoTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['temp_infos_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['temp_infos_table'] ."_tmp`
 					LIKE `". $db_settings['temp_infos_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -920,7 +920,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the user data table
 			$statusTestUserdataTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_table'] ."_tmp`
 					LIKE `". $db_settings['userdata_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -975,7 +975,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the user data cache table
 			$statusTestUserdataCacheTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_cache_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['userdata_cache_table'] ."_tmp`
 					LIKE `". $db_settings['userdata_cache_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
@@ -1008,7 +1008,7 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			// changes in the user online table
 			$statusTestUserOnlineTable = true;
 			if (empty($update['errors'])) {
-				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['useronline_table'] ."_tmp` 
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['useronline_table'] ."_tmp`
 					LIKE `". $db_settings['useronline_table'] ."`;";
 				if (!mysqli_query($connid, $qCopyTable)) {
 					$update['errors'][] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -300,6 +300,50 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['b8_wordlist_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
+			// changes of the tags table
+			$statusTestTagsTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['tags_table'] ."_tmp` 
+					LIKE `". $db_settings['tags_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestTagsTable = false;
+				} else {
+					$update['status'] = 'Tags table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['tags_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['tags_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestTagsTable = false;
+				} else {
+					$update['status'] = 'Data of tags table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['tags_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestTagsTable = false;
+				} else {
+					$update['status'] = 'Structure of tags table altered.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['tags_table'] ."_tmp`
+					CHANGE `tag` `tag` VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestTagsTable = false;
+				} else {
+					$update['status'] = 'Structure of columns in tags table altered.';
+				}
+			}
+			
 			
 			/**
 			 * From here on everything can be done as a transaction in one step

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,6 +301,51 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
+			// changes in the bookmarks table
+			$statusTestBookmarksTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['bookmarks_table'] ."_tmp` 
+					LIKE `". $db_settings['bookmarks_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestBookmarksTable = false;
+				} else {
+					$update['status'] = 'Bookmarks table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['bookmarks_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['bookmarks_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestBookmarksTable = false;
+				} else {
+					$update['status'] = 'Data of bookmarks table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['bookmarks_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestBookmarksTable = false;
+				} else {
+					$update['status'] = 'Structure of bookmarks table altered.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['bookmarks_table'] ."_tmp`
+					CHANGE `id` `id` int UNSIGNED NOT NULL AUTO_INCREMENT,
+					CHANGE `user_id` `user_id` int UNSIGNED NOT NULL,
+					CHANGE `posting_id` `posting_id` int UNSIGNED NOT NULL";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestBookmarksTable = false;
+				} else {
+					$update['status'] = 'Structure of columns in bookmarks table altered.';
+				}
+			}
+			
 			// changes in the bookmark tags table
 			$statusTestBookmarkTagsTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -301,6 +301,39 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 			if (!@mysqli_query($connid, "DROP TABLE IF EXISTS `" . $db_settings['uploads_table'] . "`")) $update['errors'][] = 'Database error in line '.__LINE__.': ' . mysqli_error($connid);
 			
 			
+			// changes in the entry cache table
+			$statusTestEntriesCacheTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['entry_cache_table'] ."_tmp` 
+					LIKE `". $db_settings['entry_cache_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestEntriesCacheTable = false;
+				} else {
+					$update['status'] = 'Entries cache table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['entry_cache_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['entry_cache_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestEntriesCacheTable = false;
+				} else {
+					$update['status'] = 'Data of entries cache table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['entry_cache_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestEntriesCacheTable = false;
+				} else {
+					$update['status'] = 'Structure of entries cache table altered.';
+				}
+			}
+			
 			// changes in the entry tags table
 			$statusTestEntryTagsTable = true;
 			if (empty($update['errors'])) {

--- a/update/update_2.4.19-2.5.php
+++ b/update/update_2.4.19-2.5.php
@@ -656,6 +656,39 @@ if (empty($update['errors']) && in_array($settings['version'], array('2.4.19', '
 				}
 			}
 			
+			// changes in the setting table
+			$statusTestSettingsTable = true;
+			if (empty($update['errors'])) {
+				$qCopyTable = "CREATE TABLE IF NOT EXISTS `". $db_settings['settings_table'] ."_tmp` 
+					LIKE `". $db_settings['settings_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyTable) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestSettingsTable = false;
+				} else {
+					$update['status'] = 'Settings table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qCopyData = "INSERT `". $db_settings['settings_table'] ."_tmp`
+					SELECT * FROM `". $db_settings['settings_table'] ."`;";
+				if (!mysqli_query($connid, $qCopyData)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestSettingsTable = false;
+				} else {
+					$update['status'] = 'Data of settings table copied.';
+				}
+			}
+			if (empty($update['errors'])) {
+				$qAlterTable = "ALTER TABLE `". $db_settings['settings_table'] ."_tmp`
+					CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
+				if (!mysqli_query($connid, $qAlterTable)) {
+					$update['errors'] = 'Database error in line '. (__LINE__ - 1) .': ' . mysqli_error($connid);
+					$statusTestSettingsTable = false;
+				} else {
+					$update['status'] = 'Structure of settings table altered.';
+				}
+			}
+			
 			// changes in the smilies table
 			$statusTestSmiliesTable = true;
 			if (empty($update['errors'])) {


### PR DESCRIPTION
Investigations launched in response to reports brought to light conceptual issues in the upgrade process. I wasn't aware of the fact, that DDL queries (in example creating or altering tables) does break the disabling of autocommit in a transaction. If in a transaction an error occures after the first DDL query, the database upgrade will stop and the software is left in an unusable intermediate state.

With this PR we will introduce a new process to perform the DDL queries, which change temporary copies of existing tables instead the original tables. The upgrade process will only continue if all DDL queries was successful. In this case the temporary tables with their new structure will replace the original tables and new data will be inserted, existing data will be changed or removed if outdated.