### PR TITLE
Add a capslock warning to the password input fields

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1210,7 +1210,7 @@ function getCapsLock(thisEl) {
 		};
 		
 		/**
-		 * Add a checkbox to a INPUT element of type PASSWORD to show/hid the entered password
+		 * Add a checkbox to an INPUT element of type PASSWORD to show/hide the entered password
 		 */
 		var togglePasswordVisibility = function() {
 			if (document.getElementById("content")) {
@@ -1513,8 +1513,8 @@ function getCapsLock(thisEl) {
 			mlf.init(ajaxPreviewStructure);
 		new DragAndDropTable(document.getElementById("sortable"), "bookmarks", "mode", "admin", "action");
 		// search for password input fields to monitor whether the Caps Lock key is pressed or not
-		// do NOT use the input type 'hidden' for searching because we change it for looking at the passwords to 'text'
 		const fldPassWords = document.querySelectorAll('#reg_pw, #new-pw, #old-pw, #pw_new_email, #password, #id_update_password, #confirm_pw_uninstall, #confirm_pw_reset, #ar_pw');
+		// do NOT use the input type 'password' for searching because we change it for looking at the passwords to 'text'
 		if (fldPassWords.length > 0)
 			fldPassWords.forEach(fldPassWords => fldPassWords.addEventListener("keyup", getCapsLock.bind(this)));
 	});

--- a/js/main.js
+++ b/js/main.js
@@ -427,6 +427,19 @@ function capsuledPreventDefault(event) {
 	event.preventDefault();
 }
 
+function getCapsLock(thisEl) {
+	const mBox = thisEl.target.closest('div').querySelector('.notice.caution');
+	if (thisEl.getModifierState("CapsLock")) {
+		if (mBox.hasAttribute('hidden')) {
+			mBox.hidden = false;
+		}
+	} else {
+		if (!mBox.hasAttribute('hidden')) {
+			mBox.hidden = true;
+		}
+	}
+}
+
 /************************ MyLittleForum-Objekte *************************************/
 
 	/**

--- a/js/main.js
+++ b/js/main.js
@@ -1513,8 +1513,8 @@ function getCapsLock(thisEl) {
 			mlf.init(ajaxPreviewStructure);
 		new DragAndDropTable(document.getElementById("sortable"), "bookmarks", "mode", "admin", "action");
 		// search for password input fields to monitor whether the Caps Lock key is pressed or not
-		const fldPassWords = document.querySelectorAll('#reg_pw, #new-pw, #old-pw, #pw_new_email, #password, #id_update_password, #confirm_pw_uninstall, #confirm_pw_reset, #ar_pw');
 		// do NOT use the input type 'password' for searching because we change it for looking at the passwords to 'text'
+		const fldPassWords = document.querySelectorAll('#password-new, #password');
 		if (fldPassWords.length > 0)
 			fldPassWords.forEach(fldPassWords => fldPassWords.addEventListener("keyup", getCapsLock.bind(this)));
 	});

--- a/js/main.js
+++ b/js/main.js
@@ -1211,29 +1211,26 @@ function getCapsLock(thisEl) {
 		
 		/**
 		 * Add a checkbox to an INPUT element of type PASSWORD to show/hide the entered password
+		 * and toggle a warning message below the password input field íf the capslock key is active
 		 */
 		var togglePasswordVisibility = function() {
-			if (document.getElementById("content")) {
-				var f = document.getElementById("content").getElementsByTagName("form");
-				if (f && f.length>0) {
-					var passwordFields = [];
-					for (var i=0; i<f.length; i++) {
-						var fields = f[i].getElementsByTagName("input");
-						for (var j=0; j<fields.length; j++) {
-							if (fields[j].type == "password") {
-								var passwordField = fields[j];
-								// lang["fold_postings_title"]
-]
-								var cb = document.createElementWithAttributes("input", {"type": "checkbox", "checked": false, "value": false, "field": passwordField, "title": lang["show_password_title"]});
-								passwordField.insertAdjacentElement('afterend', cb);
-								cb.onclick = function(e) {
-									var isShown = this.field.type == "text";
-									this.value = isShown;
-									this.title = isShown ? lang["show_password_title"] : lang["hide_password_title"];
-									this.field.type  = isShown ? "password" : "text";
-								};
-							}
-						}
+			if (document.querySelector('main')) {
+				// search for password input fields to add the visibility toggle
+				// and to monitor whether the Caps Lock key is pressed or not
+				// do NOT use the input type 'password' for searching because
+				// we change it for looking at the passwords to 'text'
+				const pwfs = document.querySelectorAll('#password-new, #password');
+				if (pwfs && pwfs.length > 0) {
+					for (let pwf of pwfs) {
+						pwf.addEventListener("keyup", getCapsLock.bind(this));
+						const cb = document.createElementWithAttributes("input", {"type": "checkbox", "checked": false, "value": false, "field": pwf, "title": lang["show_password_title"]});
+						pwf.insertAdjacentElement('afterend', cb);
+						cb.onclick = function(e) {
+							var isShown = this.field.type == "text";
+							this.value = isShown;
+							this.title = isShown ? lang["show_password_title"] : lang["hide_password_title"];
+							this.field.type  = isShown ? "password" : "text";
+						};
 					}
 				}
 			}
@@ -1512,9 +1509,4 @@ function getCapsLock(thisEl) {
 		if (mlf && typeof lang == "object") 
 			mlf.init(ajaxPreviewStructure);
 		new DragAndDropTable(document.getElementById("sortable"), "bookmarks", "mode", "admin", "action");
-		// search for password input fields to monitor whether the Caps Lock key is pressed or not
-		// do NOT use the input type 'password' for searching because we change it for looking at the passwords to 'text'
-		const fldPassWords = document.querySelectorAll('#password-new, #password');
-		if (fldPassWords.length > 0)
-			fldPassWords.forEach(fldPassWords => fldPassWords.addEventListener("keyup", getCapsLock.bind(this)));
 	});

--- a/js/main.js
+++ b/js/main.js
@@ -1505,4 +1505,9 @@ function capsuledPreventDefault(event) {
 		if (mlf && typeof lang == "object") 
 			mlf.init(ajaxPreviewStructure);
 		new DragAndDropTable(document.getElementById("sortable"), "bookmarks", "mode", "admin", "action");
+		// search for password input fields to monitor whether the Caps Lock key is pressed or not
+		// do NOT use the input type 'hidden' for searching because we change it for looking at the passwords to 'text'
+		const fldPassWords = document.querySelectorAll('#reg_pw, #new-pw, #old-pw, #pw_new_email, #password, #id_update_password, #confirm_pw_uninstall, #confirm_pw_reset, #ar_pw');
+		if (fldPassWords.length > 0)
+			fldPassWords.forEach(fldPassWords => fldPassWords.addEventListener("keyup", getCapsLock.bind(this)));
 	});

--- a/js/main.js
+++ b/js/main.js
@@ -429,15 +429,7 @@ function capsuledPreventDefault(event) {
 
 function getCapsLock(thisEl) {
 	const mBox = thisEl.target.closest('div').querySelector('.notice.caution');
-	if (thisEl.getModifierState("CapsLock")) {
-		if (mBox.hasAttribute('hidden')) {
-			mBox.hidden = false;
-		}
-	} else {
-		if (!mBox.hasAttribute('hidden')) {
-			mBox.hidden = true;
-		}
-	}
+	mBox.hidden = !thisEl.getModifierState("CapsLock");
 }
 
 /************************ MyLittleForum-Objekte *************************************/

--- a/js/main.js
+++ b/js/main.js
@@ -1223,7 +1223,9 @@ function getCapsLock(thisEl) {
 							if (fields[j].type == "password") {
 								var passwordField = fields[j];
 								// lang["fold_postings_title"]
-								var cb = document.createElementWithAttributes("input", {"type": "checkbox", "checked": false, "value": false, "field": passwordField, "title": lang["show_password_title"]}, passwordField.parentNode);
+]
+								var cb = document.createElementWithAttributes("input", {"type": "checkbox", "checked": false, "value": false, "field": passwordField, "title": lang["show_password_title"]});
+								passwordField.insertAdjacentElement('afterend', cb);
 								cb.onclick = function(e) {
 									var isShown = this.field.type == "text";
 									this.value = isShown;

--- a/lang/arabic.lang
+++ b/lang/arabic.lang
@@ -35,6 +35,7 @@ unknown_user =                    'مستخدم غير معروف'
 db_error =                        'خطأ في قاعدة البيانات!'
 mail_error =                      'خادم البريد ليس متوفر الآن - الرجاء المحاولة مرةً أخرى لاحقًا!'
 forum_disabled_admin_message =    '<!-- TODO -->The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<!-- TODO --><strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                         'عنوان'

--- a/lang/chinese.lang
+++ b/lang/chinese.lang
@@ -38,6 +38,7 @@ unknown_user =                    '游客'
 db_error =                        '数据库错误！'
 mail_error =                      '邮件服务器无法使用，请稍後再试！'
 forum_disabled_admin_message =    '<!-- TODO -->The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<!-- TODO --><strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                         '标题'

--- a/lang/chinese_traditional.lang
+++ b/lang/chinese_traditional.lang
@@ -38,6 +38,7 @@ unknown_user =                    '訪客'
 db_error =                        '資料庫錯誤！'
 mail_error =                      '郵件伺服器無法使用，請稍後再試！'
 forum_disabled_admin_message =    '<!-- TODO -->The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<!-- TODO --><strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                         '標題'

--- a/lang/croatian.lang
+++ b/lang/croatian.lang
@@ -38,6 +38,7 @@ unknown_user =                    'nepoznat'
 db_error =                        'Greška na bazi!'
 mail_error =                      'Mail poslužitelj nije dostupan - pokušajte kasnije!'
 forum_disabled_admin_message =    '<!-- TODO -->The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<!-- TODO --><strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                         'Tema'

--- a/lang/danish.lang
+++ b/lang/danish.lang
@@ -38,6 +38,7 @@ unknown_user =              'ukendt'
 db_error =                  'Database fejl!'
 mail_error =                'Mail server ikke tilgængelig - prøv venligst igen senere!'
 forum_disabled_admin_message =    '<!-- TODO -->The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<!-- TODO --><strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                   'Emne'

--- a/lang/english.lang
+++ b/lang/english.lang
@@ -35,6 +35,7 @@ unknown_user =                    'unknown'
 db_error =                        'Database error!'
 mail_error =                      'Mail server not available - please try again later!'
 forum_disabled_admin_message =    'The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                         'Subject'

--- a/lang/french.lang
+++ b/lang/french.lang
@@ -42,6 +42,7 @@ unknown_user =                    'inconnu'
 db_error =                        'Erreur base données !'
 mail_error =                      'Serveur de email indisponible - veuillez réessayer plus tard !'
 forum_disabled_admin_message =    '<!-- TODO -->The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<!-- TODO --><strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                         'Sujet'

--- a/lang/german.lang
+++ b/lang/german.lang
@@ -39,6 +39,7 @@ unknown_user =                    'unbekannt'
 db_error =                        'Datenbankfehler!'
 mail_error =                      'Mailserver nicht erreichbar – bitte später nochmal versuchen!'
 forum_disabled_admin_message =    'Das Forum ist außer Betrieb. Es kann in den Forumseinstellungen aktiviert werden.'
+capslock_warning_message =        '<strong>Achtung</strong>: Die Feststelltaste ist aktivert!'
 
 [general]
 subject =                         'Betreff'

--- a/lang/italian.lang
+++ b/lang/italian.lang
@@ -39,6 +39,7 @@ unknown_user =                    'sconosciuto'
 db_error =                        'Errore del Database!'
 mail_error =                      'Server di posta non disponibile al momento - Si prega di riprovare più tardi!'
 forum_disabled_admin_message =    '<!-- TODO -->The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<!-- TODO --><strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                         'Oggetto'

--- a/lang/norwegian.lang
+++ b/lang/norwegian.lang
@@ -36,6 +36,7 @@ unknown_user =                    'ukjent'
 db_error =                        'Databasefeil!'
 mail_error =                      'E-postserveren er ikke tilgjengelig - prøv igjen senere!'
 forum_disabled_admin_message =    '<!-- TODO -->The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<!-- TODO --><strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                         'Emne'

--- a/lang/russian.lang
+++ b/lang/russian.lang
@@ -48,6 +48,7 @@ unknown_user =                    'неизвестный'
 db_error =                        'Ошибка базы данных!'
 mail_error =                      'Почтовый сервер недоступен - пожалуйста, попробуйте позже!'
 forum_disabled_admin_message =    '<!-- TODO -->The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<!-- TODO --><strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                         'Тема'

--- a/lang/spanish.lang
+++ b/lang/spanish.lang
@@ -40,6 +40,7 @@ unknown_user =                    'desconocido'
 db_error =                        'Error en la base de datos!'
 mail_error =                      'Servidor de mail no disponible - inténtalo mas tarde'
 forum_disabled_admin_message =    '<!-- TODO -->The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<!-- TODO --><strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                         'Tema'

--- a/lang/swedish.lang
+++ b/lang/swedish.lang
@@ -39,6 +39,7 @@ unknown_user =                    'Okänd'
 db_error =                        'Databasfel!'
 mail_error =                      'Mail server inte tillgänglig - försök senare!'
 forum_disabled_admin_message =    '<!-- TODO -->The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<!-- TODO --><strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                         'Ämne'

--- a/lang/tamil.lang
+++ b/lang/tamil.lang
@@ -35,6 +35,7 @@ unknown_user =                    'தெரியாதவர்'
 db_error =                        'டேடாபேஸின் தவரு!'
 mail_error =                      'மின் அஞ்சல் சேவை காணவில்லை - தயவு செய்து மீண்டும் முயற்சிக்கவும்!'
 forum_disabled_admin_message =    '<!-- TODO -->The forum is currently disabled. Enable it in the forum settings.'
+capslock_warning_message =        '<!-- TODO --><strong>Attention</strong>: The caps lock key is enabled!'
 
 [general]
 subject =                         'பாடம்'

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -746,7 +746,7 @@ ul.openthread {
 .notice.spam {
 	background: #ffffb8 url(images/general-caution.svg) no-repeat 0.55em 0.55em/1.5em;
 }
-:is(#reg_pw, #new-pw, #old-pw, #pw_new_email, #password, #id_update_password, #confirm_pw_uninstall, #confirm_pw_reset, #ar_pw) ~ .notice {
+:is(#password-new, #password) ~ .notice {
 	margin-block: 0.25em 0.5em;
 	width: fit-content;
 }

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -746,6 +746,11 @@ ul.openthread {
 .notice.spam {
 	background: #ffffb8 url(images/general-caution.svg) no-repeat 0.55em 0.55em/1.5em;
 }
+:is(#reg_pw, #new-pw, #old-pw, #pw_new_email, #password, #id_update_password, #confirm_pw_uninstall, #confirm_pw_reset, #ar_pw) ~ .notice {
+	margin-block: 0.25em 0.5em;
+	width: fit-content;
+}
+
 html[dir="rtl"] .notice.caution,
 html[dir="rtl"] .notice.spam {
 	background-position-x: calc(100% - 0.5em);

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -145,6 +145,7 @@ ul.openthread{clear:both}
 .notice.spam{padding:.5em}
 .notice.spam,.notice.caution{border-color:#882008}
 .notice.caution,.notice.spam{background:#ffffb8 url(images/general-caution.svg) no-repeat .55em .55em/1.5em}
+:is(#reg_pw, #new-pw, #old-pw, #pw_new_email, #password, #id_update_password, #confirm_pw_uninstall, #confirm_pw_reset, #ar_pw) ~ .notice{margin-block:.25em .5em;width:fit-content}
 html[dir="rtl"] .notice.caution,html[dir="rtl"] .notice.spam{background-position-x:calc(100% - .5em)}
 .notice.ok{background:#afc url(images/tick.svg) no-repeat .55em .55em/1.5em;border-color:#086620}
 html[dir="rtl"] .notice.ok{background-position-x:calc(100% - .55em)}

--- a/themes/default/style.min.css
+++ b/themes/default/style.min.css
@@ -145,7 +145,7 @@ ul.openthread{clear:both}
 .notice.spam{padding:.5em}
 .notice.spam,.notice.caution{border-color:#882008}
 .notice.caution,.notice.spam{background:#ffffb8 url(images/general-caution.svg) no-repeat .55em .55em/1.5em}
-:is(#reg_pw, #new-pw, #old-pw, #pw_new_email, #password, #id_update_password, #confirm_pw_uninstall, #confirm_pw_reset, #ar_pw) ~ .notice{margin-block:.25em .5em;width:fit-content}
+:is(#password-new, #password) ~ .notice{margin-block:.25em .5em;width:fit-content}
 html[dir="rtl"] .notice.caution,html[dir="rtl"] .notice.spam{background-position-x:calc(100% - .5em)}
 .notice.ok{background:#afc url(images/tick.svg) no-repeat .55em .55em/1.5em;border-color:#086620}
 html[dir="rtl"] .notice.ok{background-position-x:calc(100% - .55em)}

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -773,8 +773,8 @@
   <input id="ar_email" type="text" size="25" name="ar_email" value="{$ar_email|default:''}" maxlength="{$settings.email_maxlength}" />
  </div>
  <div>
-  <label for="ar_pw" class="main">{#register_pw#}</label>
-  <input id="ar_pw" type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="ar_pw" maxlength="50" />
+  <label for="password" class="main">{#register_pw#}</label>
+  <input id="password" type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="ar_pw" maxlength="50" />
   <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div>
@@ -983,8 +983,8 @@
   </ul>
  </div>
  <div>
-  <label for="confirm_pw_reset" class="main">{#admin_confirm_password#}</label>
-  <input type="password" id="confirm_pw_reset" name="confirm_pw" spellcheck="false" autocomplete="off" writingsuggestions="false" size="20" />
+  <label for="password" class="main">{#admin_confirm_password#}</label>
+  <input type="password" id="password" name="confirm_pw" spellcheck="false" autocomplete="off" writingsuggestions="false" size="20" />
   <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div class="buttonbar">
@@ -1000,8 +1000,8 @@
  <input type="hidden" name="mode" value="admin" />
  <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
  <div>
-  <label for="confirm_pw_uninstall" class="main">{#admin_confirm_password#}</label>
-  <input type="password" id="confirm_pw_uninstall" name="confirm_pw" spellcheck="false" autocomplete="off" writingsuggestions="false" size="20" />
+  <label for="password" class="main">{#admin_confirm_password#}</label>
+  <input type="password" id="password" name="confirm_pw" spellcheck="false" autocomplete="off" writingsuggestions="false" size="20" />
   <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div class="buttonbar">
@@ -1041,8 +1041,8 @@
  <input type="hidden" name="update_file_submit" value="{$update_file}" />
  <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
  <div>
-  <label for="id_update_password">{#admin_confirm_password#}</label>
-  <input type="password" name="update_password" id="id_update_password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" />
+  <label for="password">{#admin_confirm_password#}</label>
+  <input type="password" name="update_password" id="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" />
   <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div class="buttonbar">

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -974,6 +974,7 @@
  <div>
   <label for="confirm_pw_reset" class="main">{#admin_confirm_password#}</label>
   <input type="password" id="confirm_pw_reset" name="confirm_pw" spellcheck="false" autocomplete="off" writingsuggestions="false" size="20" />
+  <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div class="buttonbar">
   <button name="reset_forum_confirmed" value="{#reset_forum_submit#}">{#reset_forum_submit#}</button>
@@ -990,6 +991,7 @@
  <div>
   <label for="confirm_pw_uninstall" class="main">{#admin_confirm_password#}</label>
   <input type="password" id="confirm_pw_uninstall" name="confirm_pw" spellcheck="false" autocomplete="off" writingsuggestions="false" size="20" />
+  <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div class="buttonbar">
   <button name="uninstall_forum_confirmed" value="{#uninstall_forum_submit#}">{#uninstall_forum_submit#}</button>
@@ -1030,6 +1032,7 @@
  <div>
   <label for="id_update_password">{#admin_confirm_password#}</label>
   <input type="password" name="update_password" id="id_update_password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" />
+  <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div class="buttonbar">
   <button name="update_submit" value="{#update_submit#}" onclick="document.getElementById('throbber-submit').removeAttribute('hidden');">{#update_submit#}</button>

--- a/themes/default/subtemplates/admin.inc.tpl
+++ b/themes/default/subtemplates/admin.inc.tpl
@@ -762,18 +762,29 @@
 </ul>
 {/if}
 <form action="index.php" method="post" accept-charset="{#charset#}">
-<div>
-<input type="hidden" name="mode" value="admin" />
-<input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
-<p><label for="ar_username" class="main">{#register_username#}</label><br />
-<input id="ar_username" type="text" size="25" name="ar_username" value="{$ar_username|default:''}" maxlength="{$settings.name_maxlength}" /></p>
-<p><label for="ar_email" class="main">{#register_email#}</label><br />
-<input id="ar_email" type="text" size="25" name="ar_email" value="{$ar_email|default:''}" maxlength="{$settings.email_maxlength}" /></p>
-<p><label for="ar_pw" class="main">{#register_pw#}</label><br />
-<input id="ar_pw" type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="ar_pw" maxlength="50" /></p>
-<p><input id="ar_send_userdata" type="checkbox" name="ar_send_userdata" value="true"{if $ar_send_userdata} checked="checked"{/if} /> <label for="ar_send_userdata">{#register_send_userdata#}</label></p>
-<p><input type="submit" name="register_submit" value="{#submit_button_ok#}" /></p>
-</div>
+ <input type="hidden" name="mode" value="admin" />
+ <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
+ <div>
+  <label for="ar_username" class="main">{#register_username#}</label>
+  <input id="ar_username" type="text" size="25" name="ar_username" value="{$ar_username|default:''}" maxlength="{$settings.name_maxlength}" />
+ </div>
+ <div>
+  <label for="ar_email" class="main">{#register_email#}</label>
+  <input id="ar_email" type="text" size="25" name="ar_email" value="{$ar_email|default:''}" maxlength="{$settings.email_maxlength}" />
+ </div>
+ <div>
+  <label for="ar_pw" class="main">{#register_pw#}</label>
+  <input id="ar_pw" type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="ar_pw" maxlength="50" />
+  <p class="notice caution" hidden>{#capslock_warning_message#}</p>
+ </div>
+ <div>
+  <ul>
+   <li><input id="ar_send_userdata" type="checkbox" name="ar_send_userdata" value="true"{if $ar_send_userdata} checked="checked"{/if} /><label for="ar_send_userdata">{#register_send_userdata#}</label></li>
+  </ul>
+ </div>
+ <div class="buttonbar">
+  <button name="register_submit" value="{#submit_button_ok#}">{#submit_button_ok#}</button>
+ </div>
 </form>
 <p class="small">{#register_exp#}</p>
 {elseif $action=='smilies'}

--- a/themes/default/subtemplates/login.inc.tpl
+++ b/themes/default/subtemplates/login.inc.tpl
@@ -19,6 +19,7 @@
    <div>
     <label for="password" class="main">{#login_password#}</label>
     <input id="password" class="login" type="password" name="userpw" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" required />
+    <p class="notice caution" hidden>{#capslock_warning_message#}</p>
    </div>
 {if $settings.autologin==1}
    <div class="normalform">

--- a/themes/default/subtemplates/register.inc.tpl
+++ b/themes/default/subtemplates/register.inc.tpl
@@ -24,6 +24,7 @@
    <div>
     <label for="reg_pw" class="main">{#register_pw#}</label>
     <input id="reg_pw" class="login" type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="30" name="{$fld_pword}" maxlength="255" required />
+    <p class="notice caution" hidden>{#capslock_warning_message#}</p>
    </div>
 
    <div class="hp">

--- a/themes/default/subtemplates/register.inc.tpl
+++ b/themes/default/subtemplates/register.inc.tpl
@@ -22,8 +22,8 @@
    </div>
 
    <div>
-    <label for="reg_pw" class="main">{#register_pw#}</label>
-    <input id="reg_pw" class="login" type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="30" name="{$fld_pword}" maxlength="255" required />
+    <label for="password" class="main">{#register_pw#}</label>
+    <input id="password" class="login" type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="30" name="{$fld_pword}" maxlength="255" required />
     <p class="notice caution" hidden>{#capslock_warning_message#}</p>
    </div>
 

--- a/themes/default/subtemplates/user_edit_email.inc.tpl
+++ b/themes/default/subtemplates/user_edit_email.inc.tpl
@@ -24,6 +24,7 @@
  <div>
   <label for="pw_new_email" class="main">{#edit_email_pw#}</label>
   <input id="pw_new_email" type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="pw_new_email" required />
+  <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div>
   <button name="edit_email_submit" value="{#submit_button_ok#}">{#submit_button_ok#}</button>

--- a/themes/default/subtemplates/user_edit_email.inc.tpl
+++ b/themes/default/subtemplates/user_edit_email.inc.tpl
@@ -22,8 +22,8 @@
   <input id="new_email_confirm" type="email" size="25" name="new_email_confirm" value="" maxlength="{$settings.email_maxlength}" required />
  </div>
  <div>
-  <label for="pw_new_email" class="main">{#edit_email_pw#}</label>
-  <input id="pw_new_email" type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="pw_new_email" required />
+  <label for="password" class="main">{#edit_email_pw#}</label>
+  <input id="password" type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="pw_new_email" required />
   <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div>

--- a/themes/default/subtemplates/user_edit_pw.inc.tpl
+++ b/themes/default/subtemplates/user_edit_pw.inc.tpl
@@ -12,13 +12,13 @@
  <input type="hidden" name="csrf_token" value="{$CSRF_TOKEN}" />
  <input type="hidden" name="mode" value="user" />
  <div>
-  <label for="old-pw">{#edit_pw_old#}</label>
-  <input type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="old_pw" id="old-pw" autofocus required />
+  <label for="password">{#edit_pw_old#}</label>
+  <input type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="old_pw" id="password" autofocus required />
   <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div>
-  <label for="new-pw">{#edit_pw_new#}</label>
-  <input type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="new_pw" id="new-pw" maxlength="255" required />
+  <label for="password-new">{#edit_pw_new#}</label>
+  <input type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="new_pw" id="password-new" maxlength="255" required />
   <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div>

--- a/themes/default/subtemplates/user_edit_pw.inc.tpl
+++ b/themes/default/subtemplates/user_edit_pw.inc.tpl
@@ -14,10 +14,12 @@
  <div>
   <label for="old-pw">{#edit_pw_old#}</label>
   <input type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="old_pw" id="old-pw" autofocus required />
+  <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div>
   <label for="new-pw">{#edit_pw_new#}</label>
   <input type="password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" name="new_pw" id="new-pw" maxlength="255" required />
+  <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div>
   <button name="edit_pw_submit" value="{#submit_button_ok#}">{#submit_button_ok#}</button>

--- a/themes/default/subtemplates/user_remove_account.inc.tpl
+++ b/themes/default/subtemplates/user_remove_account.inc.tpl
@@ -17,6 +17,7 @@
  <div>
   <label for="password">{#remove_user_confirm_password#}</label>
   <input id="password" type="password" name="user_password" spellcheck="false" autocomplete="off" writingsuggestions="false" size="25" autofocus required />
+  <p class="notice caution" hidden>{#capslock_warning_message#}</p>
  </div>
  <div>
   <button name="remove_account_submit" value="{#submit_button_ok#}">{#submit_button_ok#}</button>


### PR DESCRIPTION
Many login forms in OSses, programs and websites display a warning if the caps lock key is activated. For input fields with visible input (in example fields of type `text` or `number`) an activated caps lock key may be annoying but one can see, that something is wrong. For password fields with their hidden input this is not the case. Even one can toggle the field to show the input, one will often miss the fact that one inputs a wrong password string because of the active caps lock key. Because of this I want to introduce a warning with a message, analogue to the known implementation from many other systems.

With JS we search for all elements with IDs, used for password fields in the HTML-code of MLF. It binds a keyup-event to every found element with a loop (there are a few forum functions which need two input fields for passwords in one page). I added a message box *directly below* the password input field to the HTML-code that is hidden by default. These elements, the input field and the message box, as well as the label for the input have to be childs of a `div`.

If the keyup-event fires and the caps-lock-key is activated, the hidden attribute of the message box gets or remains removed, if the caps lock key is inactive, the message box gets back its hidden attribute. That's it.

I put the function to remove or add the hidden-attribute into the general scope of main.js because I wasn't sure about how to add it to the mylittleforum object. I am open for enhancements regarding the JS-code-structure.